### PR TITLE
11 feature: 깃토큰 db 암호화하여 저장

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -3,9 +3,9 @@ os: linux
 
 files:
   - source: /
-    destination: /home/ubuntu/enhance
+    destination: /home/ubuntu/commitato
 permissions:
-  - object: /home/ubuntu/enhance/
+  - object: /home/ubuntu/commitato/
     owner: ubuntu
     group: ubuntu
 hooks:

--- a/scripts/after-deploy.sh
+++ b/scripts/after-deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REPOSITORY=/home/ubuntu/commitato-BE
+REPOSITORY=/home/ubuntu/commitato
 cd $REPOSITORY
 
 APP_NAME=commitato-BE

--- a/src/main/java/com/leets/commitatobe/domain/commit/presentation/CommitController.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/presentation/CommitController.java
@@ -1,18 +1,22 @@
 package com.leets.commitatobe.domain.commit.presentation;
 import com.leets.commitatobe.domain.commit.presentation.dto.response.CommitResponse;
 import com.leets.commitatobe.domain.commit.usecase.FetchCommits;
+import com.leets.commitatobe.domain.commit.usecase.FetchCommitsTest;
 import com.leets.commitatobe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 
+@Tag(name = "Commit 컨트롤러", description = "GitHub에서 사용자의 Commit 정보를 호출하고 데이터 가공을 처리합니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/commit")
 public class CommitController {
     private final FetchCommits fetchCommits;
+    private final FetchCommitsTest fetchCommitsTest;
 
     @Operation(
             summary = "커밋 기록 불러오기",
@@ -20,5 +24,13 @@ public class CommitController {
     @PostMapping("/fetch")
     public ApiResponse<CommitResponse> fetchCommits(HttpServletRequest request) {
         return ApiResponse.onSuccess(fetchCommits.execute(request));
+    }
+
+    @Operation(
+            summary = "커밋 기록 불러오기 (테스트)",
+            description = "commit/fetch가 정상적으로 실행이 될 동안 사용할 임시 API")
+    @PostMapping("test/fetch")
+    public ApiResponse<CommitResponse> fetchCommits(HttpServletRequest request, @RequestHeader String accessToken) {
+        return ApiResponse.onSuccess(fetchCommitsTest.execute(request, accessToken));
     }
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
@@ -43,8 +43,7 @@ public class FetchCommits {
                     .orElseThrow(() -> new ApiException(ErrorStatus._COMMIT_NOT_FOUND))
                     .getUpdatedAt();
         } catch (ApiException e) {
-            dateTime = LocalDateTime.now();
-//            dateTime = LocalDateTime.of(2024, 07, 01, 0, 0, 0); // test 용
+            dateTime = user.getCreatedAt().toLocalDate().atStartOfDay();
         }
 
         try {

--- a/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
@@ -7,6 +7,7 @@ import com.leets.commitatobe.domain.login.usecase.LoginCommandServiceImpl;
 import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
+import com.leets.commitatobe.domain.user.usecase.UserQueryService;
 import com.leets.commitatobe.global.exception.ApiException;
 import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import com.leets.commitatobe.global.response.code.status.SuccessStatus;
@@ -30,6 +31,7 @@ public class FetchCommits {
     private final GitHubService gitHubService; // GitHub API 통신
     private final LoginCommandServiceImpl loginCommandService;
     private final LoginQueryService loginQueryService;
+    private final UserQueryService userQueryService;
 
     public CommitResponse execute(HttpServletRequest request) {
         String gitHubId = loginQueryService.getGitHubId(request);
@@ -47,8 +49,12 @@ public class FetchCommits {
         }
 
         try {
-            // Github API Access Token 저장
-            gitHubService.updateToken(loginCommandService.gitHubLogin(gitHubId));
+            // 기존: Github API Access Token 저장
+//            gitHubService.updateToken(loginCommandService.gitHubLogin(gitHubId));
+
+            //변경: DB에서 엑세스 토큰 불러오도록 방식 변경
+            String gitHubaccessToken = userQueryService.getUserGitHubAccessToken(gitHubId);
+            gitHubService.updateToken(gitHubaccessToken);
 
             List<String> repos = gitHubService.fetchRepos(gitHubId);
             ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());

--- a/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
@@ -7,6 +7,7 @@ import com.leets.commitatobe.domain.login.usecase.LoginCommandServiceImpl;
 import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
+import com.leets.commitatobe.domain.user.usecase.UserQueryService;
 import com.leets.commitatobe.global.exception.ApiException;
 import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import com.leets.commitatobe.global.response.code.status.SuccessStatus;
@@ -30,6 +31,7 @@ public class FetchCommits {
     private final GitHubService gitHubService; // GitHub API 통신
     private final LoginCommandServiceImpl loginCommandService;
     private final LoginQueryService loginQueryService;
+    private final UserQueryService userQueryService;
 
     public CommitResponse execute(HttpServletRequest request) {
         String gitHubId = loginQueryService.getGitHubId(request);
@@ -48,8 +50,12 @@ public class FetchCommits {
         }
 
         try {
-            // Github API Access Token 저장
-            gitHubService.updateToken(loginCommandService.gitHubLogin(gitHubId));
+            // 기존: Github API Access Token 저장
+//            gitHubService.updateToken(loginCommandService.gitHubLogin(gitHubId));
+
+            //변경: DB에서 엑세스 토큰 불러오도록 방식 변경
+            String gitHubaccessToken = userQueryService.getUserGitHubAccessToken(gitHubId);
+            gitHubService.updateToken(gitHubaccessToken);
 
             List<String> repos = gitHubService.fetchRepos(gitHubId);
             ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());

--- a/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommitsTest.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommitsTest.java
@@ -1,0 +1,93 @@
+package com.leets.commitatobe.domain.commit.usecase;
+
+import com.leets.commitatobe.domain.commit.domain.Commit;
+import com.leets.commitatobe.domain.commit.domain.repository.CommitRepository;
+import com.leets.commitatobe.domain.commit.presentation.dto.response.CommitResponse;
+import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
+import com.leets.commitatobe.domain.user.domain.User;
+import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
+import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
+import com.leets.commitatobe.global.response.code.status.SuccessStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Service
+@RequiredArgsConstructor
+public class FetchCommitsTest {
+    private final CommitRepository commitRepository;
+    private final UserRepository userRepository;
+    private final GitHubService gitHubService; // GitHub API 통신
+    private final LoginQueryService loginQueryService;
+
+    public CommitResponse execute(HttpServletRequest request, String accessToken) {
+        String gitHubId = loginQueryService.getGitHubId(request);
+        User user = userRepository.findByGithubId(gitHubId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));
+
+        LocalDateTime dateTime;
+        try {
+            dateTime = commitRepository.findAllByUser(user).stream()
+                    .max(Comparator.comparing(Commit::getUpdatedAt))
+                    .orElseThrow(() -> new ApiException(ErrorStatus._COMMIT_NOT_FOUND))
+                    .getUpdatedAt();
+        } catch (ApiException e) {
+            dateTime = LocalDateTime.of(2024, 7, 1, 0, 0, 0);
+        }
+
+        try {
+            // Github API Access Token 저장
+            gitHubService.updateToken(accessToken);
+
+            List<String> repos = gitHubService.fetchRepos(gitHubId);
+            ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            LocalDateTime finalDateTime = dateTime; // 오류 방지
+
+            for (String fullName : repos) {
+                CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
+                    try {
+                        gitHubService.countCommits(fullName, gitHubId, finalDateTime);
+                    } catch (IOException e) {
+                        throw new ApiException(ErrorStatus._GIT_URL_INCORRECT);
+                    }
+                }, executor);
+                futures.add(voidCompletableFuture);
+            }
+
+            CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+            allFutures.join();
+
+            executor.shutdown();
+
+            saveCommits(user);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return new CommitResponse(SuccessStatus._OK.getMessage());
+    }
+
+    private void saveCommits(User user) {
+        // 날짜별 커밋 수 DB에 저장
+        for (Map.Entry<LocalDateTime, Integer> entry : gitHubService.getCommitsByDate().entrySet()) {
+            Commit commit = commitRepository.findByCommitDateAndUser(entry.getKey(), user)
+                    .orElse(Commit.create(entry.getKey(), 0, user));
+            commit.updateCnt(entry.getValue());
+            commitRepository.save(commit);
+        }
+    }
+}

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -52,9 +52,9 @@ public class LoginController {
     @GetMapping("/callback")
     public ApiResponse<JwtResponse> githubCallback(@RequestParam("code") String code, HttpServletResponse response) {
         // GitHub에서 받은 인가 코드로 액세스 토큰 요청
-        String accessToken = loginCommandService.gitHubLogin(code);
+        String gitHubAccessToken = loginCommandService.gitHubLogin(code);
         // 액세스 토큰을 이용하여 JWT 생성
-        JwtResponse jwt = customOAuth2UserService.generateJwt(accessToken);
+        JwtResponse jwt = customOAuth2UserService.generateJwt(gitHubAccessToken);
 
         // 액세스 토큰을 헤더에 설정
         response.setHeader("Authentication", "Bearer " + jwt.accessToken());

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -4,6 +4,7 @@ import com.leets.commitatobe.domain.login.presentation.dto.GitHubDto;
 import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
 import com.leets.commitatobe.domain.login.usecase.LoginCommandService;
 import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
+import com.leets.commitatobe.domain.user.usecase.UserQueryService;
 import com.leets.commitatobe.global.config.CustomOAuth2UserService;
 import com.leets.commitatobe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +28,7 @@ public class LoginController {
 
     private final LoginCommandService loginCommandService;
     private final LoginQueryService loginQueryService;
+    private final UserQueryService userQueryService;
 
     private final CustomOAuth2UserService customOAuth2UserService;
 
@@ -70,6 +72,8 @@ public class LoginController {
     @GetMapping("/test")
     public ApiResponse<GitHubDto> test(HttpServletRequest request) {
         GitHubDto user = loginQueryService.getGitHubUser(request);
+        String gitHubAccessToken = userQueryService.getUserGitHubAccessToken(user.userId());
+        log.info("깃허브 엑세스 토큰: {}", gitHubAccessToken);
         return ApiResponse.onSuccess(user);
     }
 

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -4,6 +4,7 @@ import com.leets.commitatobe.domain.login.presentation.dto.GitHubDto;
 import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
 import com.leets.commitatobe.domain.login.usecase.LoginCommandService;
 import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
+import com.leets.commitatobe.domain.user.usecase.UserQueryService;
 import com.leets.commitatobe.global.config.CustomOAuth2UserService;
 import com.leets.commitatobe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,7 @@ public class LoginController {
 
     private final LoginCommandService loginCommandService;
     private final LoginQueryService loginQueryService;
+    private final UserQueryService userQueryService;
 
     private final CustomOAuth2UserService customOAuth2UserService;
 
@@ -68,6 +70,8 @@ public class LoginController {
     @GetMapping("/test")
     public ApiResponse<GitHubDto> test(HttpServletRequest request) {
         GitHubDto user = loginQueryService.getGitHubUser(request);
+        String gitHubAccessToken = userQueryService.getUserGitHubAccessToken(user.userId());
+        log.info("깃허브 엑세스 토큰: {}", gitHubAccessToken);
         return ApiResponse.onSuccess(user);
     }
 

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -9,14 +9,12 @@ import com.leets.commitatobe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "OAuth2 컨트롤러", description = "OAuth2 로그인 및 콜백을 처리합니다.")
 @RestController
@@ -66,7 +64,8 @@ public class LoginController {
         return ApiResponse.onSuccess(jwt);
     }
 
-    // 테스트용 API
+
+    // 테스트용 APIzz
     @GetMapping("/test")
     public ApiResponse<GitHubDto> test(HttpServletRequest request) {
         GitHubDto user = loginQueryService.getGitHubUser(request);

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -50,9 +50,9 @@ public class LoginController {
     @GetMapping("/callback")
     public ApiResponse<JwtResponse> githubCallback(@RequestParam("code") String code, HttpServletResponse response) {
         // GitHub에서 받은 인가 코드로 액세스 토큰 요청
-        String accessToken = loginCommandService.gitHubLogin(code);
+        String gitHubAccessToken = loginCommandService.gitHubLogin(code);
         // 액세스 토큰을 이용하여 JWT 생성
-        JwtResponse jwt = customOAuth2UserService.generateJwt(accessToken);
+        JwtResponse jwt = customOAuth2UserService.generateJwt(gitHubAccessToken);
 
         // 액세스 토큰을 헤더에 설정
         response.setHeader("Authentication", "Bearer " + jwt.accessToken());

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -64,8 +64,7 @@ public class LoginController {
         return ApiResponse.onSuccess(jwt);
     }
 
-
-    // 테스트용 APIzz
+    // 테스트용 API
     @GetMapping("/test")
     public ApiResponse<GitHubDto> test(HttpServletRequest request) {
         GitHubDto user = loginQueryService.getGitHubUser(request);

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandService.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandService.java
@@ -15,4 +15,5 @@ public interface LoginCommandService {
     String encrypt(String token);
 
     String decrypt(String token);
+
 }

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandService.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandService.java
@@ -12,4 +12,7 @@ public interface LoginCommandService {
     // 응답에 쿠키 설정 함수
     void setRefreshTokenCookie(HttpServletResponse response, String refreshToken);
 
+    String encrypt(String token);
+
+    String decrypt(String token);
 }

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandServiceImpl.java
@@ -157,7 +157,6 @@ public class LoginCommandServiceImpl implements LoginCommandService {
 
         return new String(decrypted, StandardCharsets.UTF_8);
     }
-
 }
 
 

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginCommandServiceImpl.java
@@ -1,17 +1,23 @@
 package com.leets.commitatobe.domain.login.usecase;
 
+import static ch.qos.logback.core.encoder.ByteArrayUtil.hexStringToByteArray;
+import static com.leets.commitatobe.global.response.code.status.ErrorStatus._DECRYPT_ERROR;
+import static com.leets.commitatobe.global.response.code.status.ErrorStatus._ENCRYPT_ERROR;
 import static com.leets.commitatobe.global.response.code.status.ErrorStatus._GITHUB_JSON_PARSING_ERROR;
 import static com.leets.commitatobe.global.response.code.status.ErrorStatus._GITHUB_TOKEN_GENERATION_ERROR;
 import static com.leets.commitatobe.global.response.code.status.ErrorStatus._REDIRECT_ERROR;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
 import com.leets.commitatobe.global.exception.ApiException;
-import com.leets.commitatobe.global.utils.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,11 +43,16 @@ public class LoginCommandServiceImpl implements LoginCommandService {
     @Value("${spring.security.oauth2.client.registration.github.redirect-uri}")
     private String redirectUri;
 
-    private final JwtProvider jwtProvider;
+    // 깃허브 엑세스 토큰 및 리프레쉬 토큰 암호화를 위한 변수
+    @Value("${jwt.aes-secret}")
+    private String aesSecret;
 
-    private final UserRepository userRepository;
+    @Value("${jwt.iv-secret}")
+    private String ivSecret;
 
-    // 예찬님! 이 함수 사용해서 accessToken 가져오심 됩니다~!
+    // 암호화 알고리즘
+    private String alg = "AES/CBC/PKCS5Padding";
+
     public String gitHubLogin(String authCode) {
         RestTemplate restTemplate = new RestTemplate();
 
@@ -108,6 +119,43 @@ public class LoginCommandServiceImpl implements LoginCommandService {
         refreshTokenCookie.setPath("/");
         refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60); // 7일 동안 유효
         response.addCookie(refreshTokenCookie);
+    }
+
+    @Override
+    public String encrypt(String token) {
+        byte[] encrypted = null;
+        try{
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(hexStringToByteArray(aesSecret), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(hexStringToByteArray(ivSecret));
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParameterSpec);
+
+            encrypted = cipher.doFinal(token.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e){
+            throw new ApiException(_ENCRYPT_ERROR);
+        }
+
+
+        return Base64.getEncoder().encodeToString(encrypted);
+    }
+
+    @Override
+    public String decrypt(String token) {
+        byte[] decrypted = null;
+
+        try{
+            Cipher cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(hexStringToByteArray(aesSecret), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(hexStringToByteArray(ivSecret));
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] decodedBytes = Base64.getDecoder().decode(token);
+            decrypted = cipher.doFinal(decodedBytes);
+        } catch (Exception e){
+            throw new ApiException(_DECRYPT_ERROR);
+        }
+
+        return new String(decrypted, StandardCharsets.UTF_8);
     }
 
 }

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
@@ -5,11 +5,13 @@ import static com.leets.commitatobe.global.response.code.status.ErrorStatus._JWT
 import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
 import com.leets.commitatobe.domain.login.presentation.dto.GitHubDto;
 import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import com.leets.commitatobe.global.utils.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,30 +23,21 @@ public class LoginQueryServiceImpl implements LoginQueryService{
 
     @Override
     public GitHubDto getGitHubUser(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader("Authorization");
-
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new ApiException(_JWT_NOT_FOUND);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ApiException(ErrorStatus._JWT_NOT_FOUND);
         }
 
-        String accessToken = authorizationHeader.substring(7); // "Bearer " 이후의 토큰 값만 추출
-        Authentication authentication = jwtProvider.getAuthentication(accessToken);
-
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-
         return userDetails.getGitHubDto();
     }
 
     @Override
     public String getGitHubId(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader("Authorization");
-
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new ApiException(_JWT_NOT_FOUND);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ApiException(ErrorStatus._JWT_NOT_FOUND);
         }
-
-        String accessToken = authorizationHeader.substring(7); // "Bearer " 이후의 토큰 값만 추출
-        Authentication authentication = jwtProvider.getAuthentication(accessToken);
 
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class LoginQueryServiceImpl implements LoginQueryService{
 
-    private final JwtProvider jwtProvider;
-
     @Override
     public GitHubDto getGitHubUser(HttpServletRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -25,7 +25,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String username;
 
     @Column(nullable = false)

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -32,9 +32,6 @@ public class User extends BaseTimeEntity {
     private String githubId;
 
     @Column
-    private String refreshToken;
-
-    @Column
     private String profileImage;
 
     @Column

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -25,6 +25,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private UUID id;
 
+    @Column
+    private String gitHubAccessToken;
+
     @Column(nullable = true)
     private String username;
 

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -25,14 +25,17 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private UUID id;
 
+    @Column
+    private String gitHubAccessToken;
+
+    @Column
+    private String refreshToken;
+
     @Column(nullable = false)
     private String username;
 
     @Column(nullable = false)
     private String githubId;
-
-    @Column
-    private String refreshToken;
 
     @Column
     private String profileImage;

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
@@ -1,0 +1,25 @@
+package com.leets.commitatobe.domain.user.presentation;
+
+import com.leets.commitatobe.global.response.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class AuthController {
+
+    //로그아웃
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(HttpServletResponse response){
+        //리프레시 토큰 쿠키 삭제
+        Cookie myCookie = new Cookie("refreshToken", null);
+        myCookie.setMaxAge(0);
+        myCookie.setPath("/");
+        response.addCookie(myCookie);
+
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
@@ -30,9 +30,9 @@ public class AuthController {
 
     //액세스 토큰 리프레시
     @PostMapping("/refresh")
-    public ApiResponse<JwtResponse> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<Object> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
         //리프레시 토큰을 통한 액세스 토큰 갱신
-        JwtResponse jwt = authService.regenerateAccessToken(request);
+        JwtResponse jwt = authService.regenerateAccessToken(request, response);
         // 액세스 토큰을 헤더에 설정
         response.setHeader("Authentication", "Bearer " + jwt.accessToken());
 

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
@@ -1,15 +1,20 @@
 package com.leets.commitatobe.domain.user.presentation;
 
+import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
+import com.leets.commitatobe.domain.user.usecase.AuthService;
 import com.leets.commitatobe.global.response.ApiResponse;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping
+@RequestMapping("/auth")
 public class AuthController {
+
+    private final AuthService authService;
 
     //로그아웃
     @PostMapping("/logout")
@@ -22,4 +27,16 @@ public class AuthController {
 
         return ApiResponse.onSuccess(null);
     }
+
+    //액세스 토큰 리프레시
+    @PostMapping("/refresh")
+    public ApiResponse<JwtResponse> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        //리프레시 토큰을 통한 액세스 토큰 갱신
+        JwtResponse jwt = authService.regenerateAccessToken(request);
+        // 액세스 토큰을 헤더에 설정
+        response.setHeader("Authentication", "Bearer " + jwt.accessToken());
+
+        return ApiResponse.onSuccess(jwt);
+    }
+
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserResponse.java
@@ -1,5 +1,15 @@
 package com.leets.commitatobe.domain.user.presentation.dto.response;
 
-public record UserResponse() {
+public record UserResponse(
+        RefreshTokenResponse refreshTokenResponse,
+        GitHubAccessTokenResponse gitHubAccessTokenResponse
+) {
+    public record RefreshTokenResponse(
+            String refreshToken
+    ) {}
 
+    public record GitHubAccessTokenResponse(
+            String gitHubAccessToken
+    ) {}
 }
+

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
@@ -2,6 +2,7 @@ package com.leets.commitatobe.domain.user.usecase;
 
 import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
 import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import com.leets.commitatobe.global.utils.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,15 +10,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static com.leets.commitatobe.global.response.code.status.ErrorStatus._REDIRECT_ERROR;
-
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final JwtProvider jwtProvider;
 
-    public JwtResponse regenerateAccessToken(HttpServletRequest request){
+    public JwtResponse regenerateAccessToken(HttpServletRequest request, HttpServletResponse response){
         //쿠키에서 리프레시 토큰 찾기
         String refreshToken = null;
         Cookie[] cookies = request.getCookies();
@@ -33,9 +32,13 @@ public class AuthService {
             return jwtProvider.regenerateTokenDto(githubId, refreshToken);
         }
         catch (Exception e) {
-            throw e;
+            //리프레시 토큰 쿠키 삭제
+            Cookie myCookie = new Cookie("refreshToken", null);
+            myCookie.setMaxAge(0);
+            myCookie.setPath("/");
+            response.addCookie(myCookie);
+            throw new ApiException(ErrorStatus._REFRESH_TOKEN_EXPIRED);
         }
-
 
     }
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
@@ -1,0 +1,41 @@
+package com.leets.commitatobe.domain.user.usecase;
+
+import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
+import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.utils.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.leets.commitatobe.global.response.code.status.ErrorStatus._REDIRECT_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtResponse regenerateAccessToken(HttpServletRequest request){
+        //쿠키에서 리프레시 토큰 찾기
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refreshToken")) {
+                refreshToken = cookie.getValue();
+            }
+        }
+
+        try {
+            jwtProvider.validateToken(refreshToken);
+            String githubId = jwtProvider.getGithubIdFromToken(refreshToken);
+            return jwtProvider.regenerateTokenDto(githubId, refreshToken);
+        }
+        catch (Exception e) {
+            throw e;
+        }
+
+
+    }
+}

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryService.java
@@ -5,5 +5,4 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserQueryService {
     String getUserGitHubAccessToken(String githubId);
-    String getUserRefreshToken(String githubId);
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryService.java
@@ -1,7 +1,9 @@
 package com.leets.commitatobe.domain.user.usecase;
 
 
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface UserQueryService {
-
+    String getUserGitHubAccessToken(String githubId);
+    String getUserRefreshToken(String githubId);
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
@@ -38,19 +38,4 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         return decodedGitHubAccessToken;
     }
-
-    @Override
-    public String getUserRefreshToken(String githubId) {
-        Optional<User> user = userRepository.findByGithubId(githubId);
-
-        if(user == null){
-            throw new ApiException(_USER_NOT_FOUND);
-        }
-
-        String refreshToken = user.get().getRefreshToken();
-
-        String decodedRefreshToken = loginCommandService.decrypt(refreshToken);
-
-        return decodedRefreshToken;
-    }
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
@@ -1,5 +1,14 @@
 package com.leets.commitatobe.domain.user.usecase;
 
+import static com.leets.commitatobe.global.response.code.status.ErrorStatus._USER_NOT_FOUND;
+
+import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
+import com.leets.commitatobe.domain.login.usecase.LoginCommandService;
+import com.leets.commitatobe.domain.user.domain.User;
+import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
+import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.utils.JwtProvider;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,5 +18,39 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserQueryServiceImpl implements UserQueryService {
+    private final JwtProvider jwtProvider;
 
+    private final UserRepository userRepository;
+
+    private final LoginCommandService loginCommandService;
+
+    @Override
+    public String getUserGitHubAccessToken(String githubId) {
+        Optional<User> user = userRepository.findByGithubId(githubId);
+
+        if(user == null){
+            throw new ApiException(_USER_NOT_FOUND);
+        }
+
+        String gitHubAccessToken = user.get().getGitHubAccessToken();
+
+        String decodedGitHubAccessToken = loginCommandService.decrypt(gitHubAccessToken);
+
+        return decodedGitHubAccessToken;
+    }
+
+    @Override
+    public String getUserRefreshToken(String githubId) {
+        Optional<User> user = userRepository.findByGithubId(githubId);
+
+        if(user == null){
+            throw new ApiException(_USER_NOT_FOUND);
+        }
+
+        String refreshToken = user.get().getRefreshToken();
+
+        String decodedRefreshToken = loginCommandService.decrypt(refreshToken);
+
+        return decodedRefreshToken;
+    }
 }

--- a/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
@@ -1,6 +1,5 @@
 package com.leets.commitatobe.global.config;
 
-import com.leets.commitatobe.domain.login.presentation.LoginController;
 import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
 import com.leets.commitatobe.domain.login.usecase.LoginCommandService;
 import com.leets.commitatobe.domain.user.domain.User;
@@ -9,7 +8,6 @@ import com.leets.commitatobe.global.utils.JwtProvider;
 import java.time.Instant;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
@@ -100,7 +100,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             .githubId(githubId)
             .username(username)
             .profileImage(profileImage)
-            .refreshToken(refreshToken)
             .build();
 
         User savedUser = userRepository.save(user);

--- a/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
@@ -1,12 +1,15 @@
 package com.leets.commitatobe.global.config;
 
+import com.leets.commitatobe.domain.login.presentation.LoginController;
 import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
+import com.leets.commitatobe.domain.login.usecase.LoginCommandService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
 import com.leets.commitatobe.global.utils.JwtProvider;
 import java.time.Instant;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,8 +40,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
+    @Autowired
+    private LoginCommandService loginCommandService;
+
     // Jwt 생성 메인 함수
-    public JwtResponse generateJwt (String authCode){
+    public JwtResponse generateJwt (String gitHubAccessToken){
         // 사용자 정보를 가져와 jwt 생성
         // ClientRegistration 객체 생성
         ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("github")
@@ -55,11 +61,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // OAuth2UserRequest 생성
         OAuth2UserRequest userRequest = new OAuth2UserRequest(
             clientRegistration,
-            new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, authCode, Instant.now(), Instant.now().plusSeconds(3600))
+            new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, gitHubAccessToken, Instant.now(), Instant.now().plusSeconds(3600))
         );
 
         // 사용자 정보와 JWT 토큰 생성
-        JwtResponse jwt = loadUserAndJwt(userRequest);
+        JwtResponse jwt = loadUserAndJwt(userRequest, gitHubAccessToken);
 
         return jwt;
     }
@@ -77,7 +83,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     // 사용자 정보를 바탕으로 jwt 생성
-    public JwtResponse loadUserAndJwt(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    public JwtResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = loadUser(userRequest);
         String githubId = oAuth2User.getAttribute("login");
 
@@ -85,22 +91,26 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // GitHub에서 받은 사용자 정보를 바탕으로 Member 엔티티를 조회하거나 새로 생성
         userRepository.findByGithubId(githubId)
-            .orElseGet(() -> createNewUser(oAuth2User, jwt.refreshToken()));
+            .orElseGet(() -> createNewUser(oAuth2User, jwt.refreshToken(), gitHubAccessToken));
 
         return jwt;
     }
 
     // User 생성 메서드
-    public User createNewUser(OAuth2User oAuth2User, String refreshToken) {
+    public User createNewUser(OAuth2User oAuth2User, String refreshToken, String gitHubAccessToken) {
         String githubId = oAuth2User.getAttribute("login");
         String username = oAuth2User.getAttribute("name");
         String profileImage = oAuth2User.getAttribute("avatar_url");
+
+        String encryptedRefreshToken = loginCommandService.encrypt(refreshToken);
+        String encryptedGitHubAccessToken = loginCommandService.encrypt(gitHubAccessToken);
 
         User user = User.builder()
             .githubId(githubId)
             .username(username)
             .profileImage(profileImage)
-            .refreshToken(refreshToken)
+            .refreshToken(encryptedRefreshToken)
+            .gitHubAccessToken(encryptedGitHubAccessToken)
             .build();
 
         User savedUser = userRepository.save(user);

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                     .loginPage("/login/github"))
                 .authorizeHttpRequests((authorize) ->
                         authorize
-                            .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**", "/login/**", "/h2-console/**", "/error/**").permitAll()
+                            .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**",
+                                    "/login/**", "/logout2", "/h2-console/**", "/error/**").permitAll()
                             .anyRequest().authenticated()
                 )
                 .headers(headers -> headers

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) ->
                         authorize
                             .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**",
-                                    "/login/**", "/logout2", "/h2-console/**", "/error/**").permitAll()
+                                    "/login/**", "/auth/**", "/h2-console/**", "/error/**").permitAll()
                             .anyRequest().authenticated()
                 )
                 .headers(headers -> headers

--- a/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT_001", "Header에 JWT가 존재하지 않습니다."),
     _GITHUB_TOKEN_GENERATION_ERROR(HttpStatus.NOT_FOUND, "JWT_002", "깃허브에서 엑세스 토큰을 발급하는 과정에서 오류가 발생했습니다."),
     _GITHUB_JSON_PARSING_ERROR(HttpStatus.NOT_FOUND, "JWT_003", "엑세스 토큰을 JSON에서 가져오는 과정에 오류가 발생했습니다."),
+    _REFRESH_TOKEN_EXPIRED(HttpStatus.NOT_FOUND, "JWT_004", "리프레시 토큰이 만료되어 재로그인이 필요합니다."),
 
     // 리다이렉션
     _REDIRECT_ERROR(HttpStatus.NOT_FOUND, "REDIRECT_001", "리다이렉트 과정에서 오류가 발생했습니다."),

--- a/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
@@ -32,7 +32,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _COMMIT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMIT_001", "커밋이 없습니다."),
 
     // GitHub API 관련
-    _GIT_URL_INCORRECT(HttpStatus.BAD_REQUEST, "GIT_001", "잘못된 URL로 요청하고 있습니다.");
+    _GIT_URL_INCORRECT(HttpStatus.BAD_REQUEST, "GIT_001", "잘못된 URL로 요청하고 있습니다."),
+
+    // 인코딩 오류
+    _ENCRYPT_ERROR(HttpStatus.BAD_REQUEST, "ENCRYPT_001", "토큰 인코딩 과정에서 오류가 발생했습니다."),
+
+    // 디코딩 오류
+    _DECRYPT_ERROR(HttpStatus.BAD_REQUEST, "DECRYPT_001", "토큰 디코딩 과정에서 오류가 발생했습니다."),
+
+    // 유저 관련
+    _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_001", "DB에서 유저를 불러오는 과정에서 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
@@ -31,7 +31,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _COMMIT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMIT_001", "커밋이 없습니다."),
 
     // GitHub API 관련
-    _GIT_URL_INCORRECT(HttpStatus.BAD_REQUEST, "GIT_001", "잘못된 URL로 요청하고 있습니다.");
+    _GIT_URL_INCORRECT(HttpStatus.BAD_REQUEST, "GIT_001", "잘못된 URL로 요청하고 있습니다."),
+
+    // 인코딩 오류
+    _ENCRYPT_ERROR(HttpStatus.BAD_REQUEST, "ENCRYPT_001", "토큰 인코딩 과정에서 오류가 발생했습니다."),
+
+    // 디코딩 오류
+    _DECRYPT_ERROR(HttpStatus.BAD_REQUEST, "DECRYPT_001", "토큰 디코딩 과정에서 오류가 발생했습니다."),
+
+    // 유저 관련
+    _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_001", "DB에서 유저를 불러오는 과정에서 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -26,7 +26,9 @@ import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
 public class JwtProvider {
 
     private final Key key;
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; //access 30분
+
+    //private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; //refresh 7일
 
     public JwtProvider(@Value("${jwt.secret}") String secretKey) {

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -43,6 +43,12 @@ public class JwtProvider {
         return new JwtResponse("bearer", accessToken, refreshToken);
     }
 
+    // AccessToken 재생성하는 메서드
+    public JwtResponse regenerateTokenDto(String githubId, String refreshToken) {
+        String accessToken = generateAccessToken(githubId);
+        return new JwtResponse("bearer", accessToken, refreshToken);
+    }
+
     // Access Token 생성
     public String generateAccessToken(String githubId){
         long now = (new Date()).getTime();
@@ -59,12 +65,11 @@ public class JwtProvider {
     public String generateRefreshToken(String githubId){
         long now = (new Date()).getTime();
         return Jwts.builder()
+                .setSubject(githubId) // "sub" 클레임에 사용자 ID 저장
                 .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
     }
-
-
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {
@@ -122,6 +127,16 @@ public class JwtProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
+    }
+
+    public String getGithubIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        String githubId = claims.getSubject();
+        return githubId;
     }
 
 }

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -26,9 +26,12 @@ import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
 public class JwtProvider {
 
     private final Key key;
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; //access 30분
 
-    //private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
+    //테스트용
+    //private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; //access 1분
+    //private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 3; //refresh 3분
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; //refresh 7일
 
     public JwtProvider(@Value("${jwt.secret}") String secretKey) {

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -36,26 +36,33 @@ public class JwtProvider {
 
     // AccessToken, RefreshToken을 생성하는 메서드
     public JwtResponse generateTokenDto(String githubId) {
-
-        long now = (new Date()).getTime();
-
-        // Access Token 생성
-        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
-        String accessToken = Jwts.builder()
-            .setSubject(githubId) // "sub" 클레임에 사용자 ID 저장
-            .claim("auth", "ROLE_USER") // 권한 정보 추가
-            .setExpiration(accessTokenExpiresIn)
-            .signWith(key, SignatureAlgorithm.HS512)
-            .compact();
-
-        // Refresh Token 생성
-        String refreshToken = Jwts.builder()
-            .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
-            .signWith(key, SignatureAlgorithm.HS512)
-            .compact();
-
+        String accessToken = generateAccessToken(githubId);
+        String refreshToken = generateRefreshToken(githubId);
         return new JwtResponse("bearer", accessToken, refreshToken);
     }
+
+    // Access Token 생성
+    public String generateAccessToken(String githubId){
+        long now = (new Date()).getTime();
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        return Jwts.builder()
+                .setSubject(githubId) // "sub" 클레임에 사용자 ID 저장
+                .claim("auth", "ROLE_USER") // 권한 정보 추가
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // Refresh Token 생성
+    public String generateRefreshToken(String githubId){
+        long now = (new Date()).getTime();
+        return Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -24,7 +24,7 @@ spring:
             client-id: ${CLIENT_ID}
             client-secret: ${CLIENT_SECRET}
             scope: read:user
-            redirect-uri: "http://localhost:8080/login/callback"
+            redirect-uri: ${REDIRECT_URL}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -28,3 +28,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
+  aes-secret: ${AES_SECRET}
+  iv-secret: ${IV_SECRET}
+
+domain-uri: ${DOMAIN_URI}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/commitato
     username: root
-    password: 1220
+    password:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -25,3 +25,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
+  aes-secret: ${AES_SECRET}
+  iv-secret: ${IV_SECRET}
+
+domain-uri: ${DOMAIN_URI}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,12 +2,12 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/commitato
     username: root
-    password:
+    password: 1220
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
     properties:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: local
+    default: dev

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: dev
+    default: local


### PR DESCRIPTION
## 📌 요약

- 깃토큰과 리프레쉬 토큰을 AES 알고리즘을 통해 인코딩 후, DB에 저장하는 방식으로 변경

## 📝 상세 내용

- DB에 인코딩되어 저장되는 것 확인
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/70458f38-b1d6-46d3-8f18-46743b6da27e">

- 터미널을 통해 실제로 디코딩이 잘 동작하는지 확인
![image](https://github.com/user-attachments/assets/135c5553-ad35-49e4-8ced-7787421a1d75)

- test api를 통해 디코딩까지 잘 동작하는지 확인
![image](https://github.com/user-attachments/assets/72989976-56ed-4f57-aab9-ec63e180e177)

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #11 
