### PR TITLE
10 fix 리프레시 토큰 수정 및 로그아웃

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -9,14 +9,12 @@ import com.leets.commitatobe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "OAuth2 컨트롤러", description = "OAuth2 로그인 및 콜백을 처리합니다.")
 @RestController
@@ -66,7 +64,8 @@ public class LoginController {
         return ApiResponse.onSuccess(jwt);
     }
 
-    // 테스트용 API
+
+    // 테스트용 APIzz
     @GetMapping("/test")
     public ApiResponse<GitHubDto> test(HttpServletRequest request) {
         GitHubDto user = loginQueryService.getGitHubUser(request);

--- a/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/presentation/LoginController.java
@@ -64,8 +64,7 @@ public class LoginController {
         return ApiResponse.onSuccess(jwt);
     }
 
-
-    // 테스트용 APIzz
+    // 테스트용 API
     @GetMapping("/test")
     public ApiResponse<GitHubDto> test(HttpServletRequest request) {
         GitHubDto user = loginQueryService.getGitHubUser(request);

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
@@ -5,11 +5,13 @@ import static com.leets.commitatobe.global.response.code.status.ErrorStatus._JWT
 import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
 import com.leets.commitatobe.domain.login.presentation.dto.GitHubDto;
 import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import com.leets.commitatobe.global.utils.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,30 +23,21 @@ public class LoginQueryServiceImpl implements LoginQueryService{
 
     @Override
     public GitHubDto getGitHubUser(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader("Authorization");
-
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new ApiException(_JWT_NOT_FOUND);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ApiException(ErrorStatus._JWT_NOT_FOUND);
         }
 
-        String accessToken = authorizationHeader.substring(7); // "Bearer " 이후의 토큰 값만 추출
-        Authentication authentication = jwtProvider.getAuthentication(accessToken);
-
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-
         return userDetails.getGitHubDto();
     }
 
     @Override
     public String getGitHubId(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader("Authorization");
-
-        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new ApiException(_JWT_NOT_FOUND);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+            throw new ApiException(ErrorStatus._JWT_NOT_FOUND);
         }
-
-        String accessToken = authorizationHeader.substring(7); // "Bearer " 이후의 토큰 값만 추출
-        Authentication authentication = jwtProvider.getAuthentication(accessToken);
 
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 

--- a/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/usecase/LoginQueryServiceImpl.java
@@ -19,8 +19,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class LoginQueryServiceImpl implements LoginQueryService{
 
-    private final JwtProvider jwtProvider;
-
     @Override
     public GitHubDto getGitHubUser(HttpServletRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -25,7 +25,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private UUID id;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String username;
 
     @Column(nullable = false)

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -32,9 +32,6 @@ public class User extends BaseTimeEntity {
     private String githubId;
 
     @Column
-    private String refreshToken;
-
-    @Column
     private String profileImage;
 
     @Column

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
@@ -1,0 +1,25 @@
+package com.leets.commitatobe.domain.user.presentation;
+
+import com.leets.commitatobe.global.response.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class AuthController {
+
+    //로그아웃
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(HttpServletResponse response){
+        //리프레시 토큰 쿠키 삭제
+        Cookie myCookie = new Cookie("refreshToken", null);
+        myCookie.setMaxAge(0);
+        myCookie.setPath("/");
+        response.addCookie(myCookie);
+
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
@@ -30,9 +30,9 @@ public class AuthController {
 
     //액세스 토큰 리프레시
     @PostMapping("/refresh")
-    public ApiResponse<JwtResponse> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<Object> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
         //리프레시 토큰을 통한 액세스 토큰 갱신
-        JwtResponse jwt = authService.regenerateAccessToken(request);
+        JwtResponse jwt = authService.regenerateAccessToken(request, response);
         // 액세스 토큰을 헤더에 설정
         response.setHeader("Authentication", "Bearer " + jwt.accessToken());
 

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/AuthController.java
@@ -1,15 +1,20 @@
 package com.leets.commitatobe.domain.user.presentation;
 
+import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
+import com.leets.commitatobe.domain.user.usecase.AuthService;
 import com.leets.commitatobe.global.response.ApiResponse;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping
+@RequestMapping("/auth")
 public class AuthController {
+
+    private final AuthService authService;
 
     //로그아웃
     @PostMapping("/logout")
@@ -22,4 +27,16 @@ public class AuthController {
 
         return ApiResponse.onSuccess(null);
     }
+
+    //액세스 토큰 리프레시
+    @PostMapping("/refresh")
+    public ApiResponse<JwtResponse> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        //리프레시 토큰을 통한 액세스 토큰 갱신
+        JwtResponse jwt = authService.regenerateAccessToken(request);
+        // 액세스 토큰을 헤더에 설정
+        response.setHeader("Authentication", "Bearer " + jwt.accessToken());
+
+        return ApiResponse.onSuccess(jwt);
+    }
+
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
@@ -2,6 +2,7 @@ package com.leets.commitatobe.domain.user.usecase;
 
 import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
 import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import com.leets.commitatobe.global.utils.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,15 +10,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static com.leets.commitatobe.global.response.code.status.ErrorStatus._REDIRECT_ERROR;
-
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final JwtProvider jwtProvider;
 
-    public JwtResponse regenerateAccessToken(HttpServletRequest request){
+    public JwtResponse regenerateAccessToken(HttpServletRequest request, HttpServletResponse response){
         //쿠키에서 리프레시 토큰 찾기
         String refreshToken = null;
         Cookie[] cookies = request.getCookies();
@@ -33,9 +32,13 @@ public class AuthService {
             return jwtProvider.regenerateTokenDto(githubId, refreshToken);
         }
         catch (Exception e) {
-            throw e;
+            //리프레시 토큰 쿠키 삭제
+            Cookie myCookie = new Cookie("refreshToken", null);
+            myCookie.setMaxAge(0);
+            myCookie.setPath("/");
+            response.addCookie(myCookie);
+            throw new ApiException(ErrorStatus._REFRESH_TOKEN_EXPIRED);
         }
-
 
     }
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/AuthService.java
@@ -1,0 +1,41 @@
+package com.leets.commitatobe.domain.user.usecase;
+
+import com.leets.commitatobe.domain.login.presentation.dto.JwtResponse;
+import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.utils.JwtProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.leets.commitatobe.global.response.code.status.ErrorStatus._REDIRECT_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+
+    public JwtResponse regenerateAccessToken(HttpServletRequest request){
+        //쿠키에서 리프레시 토큰 찾기
+        String refreshToken = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refreshToken")) {
+                refreshToken = cookie.getValue();
+            }
+        }
+
+        try {
+            jwtProvider.validateToken(refreshToken);
+            String githubId = jwtProvider.getGithubIdFromToken(refreshToken);
+            return jwtProvider.regenerateTokenDto(githubId, refreshToken);
+        }
+        catch (Exception e) {
+            throw e;
+        }
+
+
+    }
+}

--- a/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/config/CustomOAuth2UserService.java
@@ -100,7 +100,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             .githubId(githubId)
             .username(username)
             .profileImage(profileImage)
-            .refreshToken(refreshToken)
             .build();
 
         User savedUser = userRepository.save(user);

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
                     .loginPage("/login/github"))
                 .authorizeHttpRequests((authorize) ->
                         authorize
-                            .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**", "/login/**", "/h2-console/**", "/error/**").permitAll()
+                            .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**",
+                                    "/login/**", "/logout2", "/h2-console/**", "/error/**").permitAll()
                             .anyRequest().authenticated()
                 )
                 .headers(headers -> headers

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) ->
                         authorize
                             .requestMatchers("/", "/v3/api-docs/**", "/swagger-ui/**",
-                                    "/login/**", "/logout2", "/h2-console/**", "/error/**").permitAll()
+                                    "/login/**", "/auth/**", "/h2-console/**", "/error/**").permitAll()
                             .anyRequest().authenticated()
                 )
                 .headers(headers -> headers

--- a/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/leets/commitatobe/global/response/code/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT_001", "Header에 JWT가 존재하지 않습니다."),
     _GITHUB_TOKEN_GENERATION_ERROR(HttpStatus.NOT_FOUND, "JWT_002", "깃허브에서 엑세스 토큰을 발급하는 과정에서 오류가 발생했습니다."),
     _GITHUB_JSON_PARSING_ERROR(HttpStatus.NOT_FOUND, "JWT_003", "엑세스 토큰을 JSON에서 가져오는 과정에 오류가 발생했습니다."),
+    _REFRESH_TOKEN_EXPIRED(HttpStatus.NOT_FOUND, "JWT_004", "리프레시 토큰이 만료되어 재로그인이 필요합니다."),
 
     // 리다이렉션
     _REDIRECT_ERROR(HttpStatus.NOT_FOUND, "REDIRECT_001", "리다이렉트 과정에서 오류가 발생했습니다."),

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -26,7 +26,9 @@ import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
 public class JwtProvider {
 
     private final Key key;
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; //access 30분
+
+    //private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; //refresh 7일
 
     public JwtProvider(@Value("${jwt.secret}") String secretKey) {

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -43,6 +43,12 @@ public class JwtProvider {
         return new JwtResponse("bearer", accessToken, refreshToken);
     }
 
+    // AccessToken 재생성하는 메서드
+    public JwtResponse regenerateTokenDto(String githubId, String refreshToken) {
+        String accessToken = generateAccessToken(githubId);
+        return new JwtResponse("bearer", accessToken, refreshToken);
+    }
+
     // Access Token 생성
     public String generateAccessToken(String githubId){
         long now = (new Date()).getTime();
@@ -59,12 +65,11 @@ public class JwtProvider {
     public String generateRefreshToken(String githubId){
         long now = (new Date()).getTime();
         return Jwts.builder()
+                .setSubject(githubId) // "sub" 클레임에 사용자 ID 저장
                 .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
     }
-
-
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {
@@ -122,6 +127,16 @@ public class JwtProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
+    }
+
+    public String getGithubIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        String githubId = claims.getSubject();
+        return githubId;
     }
 
 }

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -26,9 +26,12 @@ import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
 public class JwtProvider {
 
     private final Key key;
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; //access 30분
 
-    //private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
+    //테스트용
+    //private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; //access 1분
+    //private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 3; //refresh 3분
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //access 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; //refresh 7일
 
     public JwtProvider(@Value("${jwt.secret}") String secretKey) {

--- a/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/utils/JwtProvider.java
@@ -36,26 +36,33 @@ public class JwtProvider {
 
     // AccessToken, RefreshToken을 생성하는 메서드
     public JwtResponse generateTokenDto(String githubId) {
-
-        long now = (new Date()).getTime();
-
-        // Access Token 생성
-        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
-        String accessToken = Jwts.builder()
-            .setSubject(githubId) // "sub" 클레임에 사용자 ID 저장
-            .claim("auth", "ROLE_USER") // 권한 정보 추가
-            .setExpiration(accessTokenExpiresIn)
-            .signWith(key, SignatureAlgorithm.HS512)
-            .compact();
-
-        // Refresh Token 생성
-        String refreshToken = Jwts.builder()
-            .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
-            .signWith(key, SignatureAlgorithm.HS512)
-            .compact();
-
+        String accessToken = generateAccessToken(githubId);
+        String refreshToken = generateRefreshToken(githubId);
         return new JwtResponse("bearer", accessToken, refreshToken);
     }
+
+    // Access Token 생성
+    public String generateAccessToken(String githubId){
+        long now = (new Date()).getTime();
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        return Jwts.builder()
+                .setSubject(githubId) // "sub" 클레임에 사용자 ID 저장
+                .claim("auth", "ROLE_USER") // 권한 정보 추가
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // Refresh Token 생성
+    public String generateRefreshToken(String githubId){
+        long now = (new Date()).getTime();
+        return Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+
 
     // Jwt 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,12 +2,12 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/commitato
     username: root
-    password:
+    password: 1220
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
     properties:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: dev
+    default: local


### PR DESCRIPTION
## 📌 요약

- 리프레시 토큰 수정 및 로그아웃

## 📝 상세 내용

1. 로그아웃
- 쿠키에 저장된 리프레시 토큰 삭제
- 액세스 토큰은 헤더에 저장하기때문에 프론트 측에서 처리 필요

2. 리프레시 토큰 로직 구현
- 액세스 토큰 갱신 요청이 오면 리프레시 토큰의 유효성 검증
- 유효할 시 액세스 토큰 재발급, 유효하지 않으면 로그아웃 및 재로그인 예외 처리

## 🗣️ 질문 및 이외 사항

- 초기 로그인 구현 단계에서 리프레시 토큰을 db에도 저장하고, 쿠키에도 저장하였는데 두 가기 중 한 가지 방식만 사용하면 되기 때문에 쿠키 방식을 사용하였습니다. **따라서 db 칼럼에서 삭제하였으니 확인 부탁드립니다!**
- 로그인 테스트는 postman으로 쿠키 설정을 통해 진행하였습니다.
  -  참조링크 https://annajin.tistory.com/214

## ☑️ 이슈 번호

- close #10 
