### PR TITLE
22 bug 사용자 exp 초기화 오류 수정

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class User extends BaseTimeEntity {
 
     @Id
@@ -34,7 +35,8 @@ public class User extends BaseTimeEntity {
     private String profileImage;
 
     @Column(nullable = false)
-    private Integer exp;
+    @Builder.Default
+    private Integer exp = 0;
 
     @Column
     private Integer commitDays;
@@ -75,9 +77,4 @@ public class User extends BaseTimeEntity {
     public void updateTodayCommitCount(Integer todayCommitCount){
         this.todayCommitCount=todayCommitCount;
     }
-
-    public User(){
-        this.exp=0;
-    }
-
 }


### PR DESCRIPTION
## 📌 요약

- 사용자 exp 초기화 오류 수정

## 📝 상세 내용

- 빌더 패턴 사용 시, 기본 생성자가 실행 안되는 경우 발생
- @Builder.Default 어노테이션을 사용해 사용자의 exp 값 초기화

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #22 
