### PR TITLE
31 fearture commit/fetch API에 DTO 추가

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/presentation/CommitController.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/presentation/CommitController.java
@@ -19,17 +19,17 @@ public class CommitController {
     private final FetchCommitsTest fetchCommitsTest;
 
     @Operation(
-            summary = "커밋 기록 불러오기",
-            description = "GitHub에서 커밋 기록을 가져와 DB에 저장합니다.")
-    @PostMapping("/fetch")
+            summary = "커밋 기록 업데이트",
+            description = "GitHub에서 커밋 기록을 가져와 DB에 저장하고 사용자의 정보를 최신화 합니다.")
+    @PostMapping("/update")
     public ApiResponse<CommitResponse> fetchCommits(HttpServletRequest request) {
         return ApiResponse.onSuccess(fetchCommits.execute(request));
     }
 
     @Operation(
-            summary = "커밋 기록 불러오기 (테스트)",
-            description = "테스트를 위해, 7월 1일부터 커밋 기록을 가져와 DB에 저장합니다.")
-    @PostMapping("test/fetch")
+            summary = "커밋 기록 업데이트 (테스트)",
+            description = "테스트를 위해, 7월 1일부터 커밋 기록을 가져와 DB에 저장하고 사용자의 정보를 최신화 합니다.")
+    @PostMapping("update/test")
     public ApiResponse<CommitResponse> fetchCommitsTest(HttpServletRequest request) {
         return ApiResponse.onSuccess(fetchCommitsTest.execute(request));
     }

--- a/src/main/java/com/leets/commitatobe/domain/commit/presentation/dto/response/CommitResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/presentation/dto/response/CommitResponse.java
@@ -1,6 +1,34 @@
 package com.leets.commitatobe.domain.commit.presentation.dto.response;
 
+import com.leets.commitatobe.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(access = AccessLevel.PRIVATE)
 public record CommitResponse(
-        String message
+        Boolean isMyAccount,
+        String githubId,
+        Integer exp,
+        String tierName,
+        String characterUrl,
+        Integer consecutiveCommitDays,
+        Integer todayCommitCount,
+        Integer totalCommitCount,
+        LocalDateTime updatedAt
 ) {
+    public static CommitResponse of(boolean isMyAccount, User user){
+        return CommitResponse.builder()
+                .isMyAccount(isMyAccount)
+                .githubId(user.getGithubId())
+                .exp(user.getExp())
+                .tierName(user.getTier().getTierName())
+                .characterUrl(user.getTier().getCharacterUrl())
+                .consecutiveCommitDays(user.getConsecutiveCommitDays())
+                .todayCommitCount(user.getTodayCommitCount())
+                .totalCommitCount(user.getTotalCommitCount())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommits.java
@@ -3,14 +3,12 @@ package com.leets.commitatobe.domain.commit.usecase;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.domain.repository.CommitRepository;
 import com.leets.commitatobe.domain.commit.presentation.dto.response.CommitResponse;
-import com.leets.commitatobe.domain.login.usecase.LoginCommandServiceImpl;
 import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
 import com.leets.commitatobe.domain.user.usecase.UserQueryService;
 import com.leets.commitatobe.global.exception.ApiException;
 import com.leets.commitatobe.global.response.code.status.ErrorStatus;
-import com.leets.commitatobe.global.response.code.status.SuccessStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -29,7 +27,6 @@ public class FetchCommits {
     private final CommitRepository commitRepository;
     private final UserRepository userRepository;
     private final GitHubService gitHubService; // GitHub API 통신
-    private final LoginCommandServiceImpl loginCommandService;
     private final LoginQueryService loginQueryService;
     private final ExpService expService;
     private final UserQueryService userQueryService;
@@ -85,7 +82,7 @@ public class FetchCommits {
             throw new RuntimeException(e);
         }
 
-        return new CommitResponse(SuccessStatus._OK.getMessage());
+        return CommitResponse.of(true, user);
     }
 
     private void saveCommits(User user) {

--- a/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommitsTest.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/usecase/FetchCommitsTest.java
@@ -3,14 +3,12 @@ package com.leets.commitatobe.domain.commit.usecase;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.domain.repository.CommitRepository;
 import com.leets.commitatobe.domain.commit.presentation.dto.response.CommitResponse;
-import com.leets.commitatobe.domain.login.usecase.LoginCommandServiceImpl;
 import com.leets.commitatobe.domain.login.usecase.LoginQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.domain.repository.UserRepository;
 import com.leets.commitatobe.domain.user.usecase.UserQueryService;
 import com.leets.commitatobe.global.exception.ApiException;
 import com.leets.commitatobe.global.response.code.status.ErrorStatus;
-import com.leets.commitatobe.global.response.code.status.SuccessStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -29,7 +27,6 @@ public class FetchCommitsTest {
     private final CommitRepository commitRepository;
     private final UserRepository userRepository;
     private final GitHubService gitHubService; // GitHub API 통신
-    private final LoginCommandServiceImpl loginCommandService;
     private final LoginQueryService loginQueryService;
     private final ExpService expService;
     private final UserQueryService userQueryService;
@@ -82,7 +79,7 @@ public class FetchCommitsTest {
             throw new RuntimeException(e);
         }
 
-        return new CommitResponse(SuccessStatus._OK.getMessage());
+        return CommitResponse.of(true, user);
     }
 
     private void saveCommits(User user) {

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserInfoResponse.java
@@ -1,17 +1,16 @@
 package com.leets.commitatobe.domain.user.presentation.dto.response;
 
-import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record UserInfoResponse(
         Boolean isMyAccount,
         String githubId,
+        Integer exp,
         String tierName,
         String characterUrl,
         Integer consecutiveCommitDays,
@@ -23,6 +22,7 @@ public record UserInfoResponse(
         return UserInfoResponse.builder()
                 .isMyAccount(isMyAccount)
                 .githubId(user.getGithubId())
+                .exp(user.getExp())
                 .tierName(user.getTier().getTierName())
                 .characterUrl(user.getTier().getCharacterUrl())
                 .consecutiveCommitDays(user.getConsecutiveCommitDays())

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserRankResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserRankResponse.java
@@ -1,7 +1,7 @@
 package com.leets.commitatobe.domain.user.presentation.dto.response;
 
 public record UserRankResponse(
-        String username,
+        String githubId,
         Integer exp,
         Integer consecutiveCommitDays,
         String tierName,

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
@@ -39,8 +39,8 @@ public class UserQueryServiceImpl implements UserQueryService {
                 user.getRanking(),
                 user.getGithubId(),
                 tier.getTierName(),
-                user.getConsecutiveCommitDays(),
-                user.getExp()
+                user.getExp(),
+                user.getConsecutiveCommitDays()
         );
     }
 

--- a/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/usecase/UserQueryServiceImpl.java
@@ -57,7 +57,7 @@ public class UserQueryServiceImpl implements UserQueryService {
             Tier tier = user.getTier();
 
             return new UserRankResponse(
-                    user.getUsername(),
+                    user.getGithubId(),
                     user.getExp(),
                     user.getConsecutiveCommitDays(),
                     tier != null ? tier.getTierName() : "Unranked",


### PR DESCRIPTION
## 📌 요약
- `commit/fetch`의 응답 DTO에 사용자의 정보를 출력합니다.
- `commit/fetch`의 API의 URL을 의도에 맞게 `commit/update`로 변경합니다.
- 자잘한 버그들을 수정했습니다.

## 📝 상세 내용
1. `commit/fetch`의 응답 DTO에 사용자의 정보를 출력합니다.
<img width="732" alt="image" src="https://github.com/user-attachments/assets/358fbce5-ffe5-45b2-85e0-369908eb74f4">


2. `commit/fetch`의 API의 URL을 의도에 맞게 `commit/update`로 변경합니다.
<img width="455" alt="image" src="https://github.com/user-attachments/assets/5921cb89-bdaa-412f-ba02-c70bd5f0e44a">

3. 유저 검색 DTO의 필드가 의도한대로 동작하지 않는 오류를 수정했습니다.
<img width="332" alt="image" src="https://github.com/user-attachments/assets/fe2cc194-f611-4c9e-afcc-802f790407e8">

4. 유저 정보 DTO에 경험치 필드가 누락된 오류를 수정했습니다.
<img width="731" alt="image" src="https://github.com/user-attachments/assets/667e85c9-5c8f-42e9-83b2-6cb6fb488889">


## 🗣️ 질문 및 이외 사항
-

## ☑️ 이슈 번호

- close #31
