### PR TITLE
fix: 유저 페이지 응답 DTO에 랭킹 추가

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/presentation/dto/response/CommitResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/presentation/dto/response/CommitResponse.java
@@ -11,6 +11,7 @@ public record CommitResponse(
         Boolean isMyAccount,
         String githubId,
         Integer exp,
+        Integer ranking,
         String tierName,
         String characterUrl,
         Integer consecutiveCommitDays,
@@ -23,6 +24,7 @@ public record CommitResponse(
                 .isMyAccount(isMyAccount)
                 .githubId(user.getGithubId())
                 .exp(user.getExp())
+                .ranking(user.getRanking())
                 .tierName(user.getTier().getTierName())
                 .characterUrl(user.getTier().getCharacterUrl())
                 .consecutiveCommitDays(user.getConsecutiveCommitDays())

--- a/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/presentation/dto/response/UserInfoResponse.java
@@ -11,6 +11,7 @@ public record UserInfoResponse(
         Boolean isMyAccount,
         String githubId,
         Integer exp,
+        Integer ranking,
         String tierName,
         String characterUrl,
         Integer consecutiveCommitDays,
@@ -23,6 +24,7 @@ public record UserInfoResponse(
                 .isMyAccount(isMyAccount)
                 .githubId(user.getGithubId())
                 .exp(user.getExp())
+                .ranking(user.getRanking())
                 .tierName(user.getTier().getTierName())
                 .characterUrl(user.getTier().getCharacterUrl())
                 .consecutiveCommitDays(user.getConsecutiveCommitDays())


### PR DESCRIPTION
## 📌 요약
- 사용자 정보 페이지를 불러오는 모든 API들의 응답 DTO에 랭킹이 빠져있는 문제를 해결하였습니다.

## 📝 상세 내용

## 🗣️ 질문 및 이외 사항

## ☑️ 이슈 번호
- close #35
