### PR TITLE
refactor: GitHub API 통신 방식 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature
 about: 새로운 기능을 제안하기 위한 이슈 템플릿
-title: "[FEARTURE]"
+title: "[FEATURE]"
 labels: "feature"
 assignees: ''
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/controller/CommitController.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/controller/CommitController.java
@@ -31,7 +31,7 @@ public class CommitController {
 
 	@Operation(
 		summary = "커밋 기록 업데이트 (테스트)",
-		description = "테스트를 위해, 7월 1일부터 커밋 기록을 가져와 DB에 저장하고 사용자의 정보를 최신화 합니다.")
+		description = "테스트를 위해, 최근 3개월의 커밋 기록을 가져와 DB에 저장하고 사용자의 정보를 최신화 합니다.")
 	@PostMapping("update/test")
 	public ApiResponse<CommitResponse> fetchCommitsTest() {
 		return ApiResponse.onSuccess(fetchCommitsTest.execute());

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -1,6 +1,5 @@
 package com.leets.commitatobe.domain.commit.service;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +18,6 @@ import com.leets.commitatobe.domain.login.service.LoginQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
-import com.leets.commitatobe.global.exception.ApiException;
-import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -59,11 +56,7 @@ public class FetchCommits {
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
-					try {
-						gitHubService.countCommits(fullName, gitHubId, finalDateTime);
-					} catch (IOException e) {
-						throw new ApiException(ErrorStatus._GIT_URL_INCORRECT);
-					}
+					gitHubService.countCommits(fullName, gitHubId, finalDateTime);
 				}, executor);
 				futures.add(voidCompletableFuture);
 			}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
@@ -1,6 +1,5 @@
 package com.leets.commitatobe.domain.commit.service;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +18,6 @@ import com.leets.commitatobe.domain.login.service.LoginQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
-import com.leets.commitatobe.global.exception.ApiException;
-import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -56,11 +53,7 @@ public class FetchCommitsTest {
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
-					try {
-						gitHubService.countCommits(fullName, gitHubId, finalDateTime);
-					} catch (IOException e) {
-						throw new ApiException(ErrorStatus._GIT_URL_INCORRECT);
-					}
+					gitHubService.countCommits(fullName, gitHubId, finalDateTime);
 				}, executor);
 				futures.add(voidCompletableFuture);
 			}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
@@ -39,7 +39,7 @@ public class FetchCommitsTest {
 		LocalDateTime dateTime = user.getLastCommitUpdateTime();
 
 		if (dateTime == null) {
-			dateTime = LocalDateTime.of(2024, 7, 1, 0, 0, 0);
+			dateTime = LocalDateTime.now().minusMonths(3);
 		}
 
 		try {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -75,14 +75,7 @@ public class GitHubService {
 			return true;
 		}
 
-		Mono<JsonArray> contributorsMono = webClient.get()
-			.uri("/repos/" + fullName + "/contributors")
-			.header(HttpHeaders.AUTHORIZATION, "token " + AUTH_TOKEN)
-			.retrieve()
-			.bodyToMono(String.class)
-			.map(response -> JsonParser.parseString(response).getAsJsonArray());
-
-		JsonArray contributors = contributorsMono.block();
+		JsonArray contributors = getConnection("/repos/" + fullName + "/contributors");
 
 		if (contributors == null) {
 			return false;

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -1,9 +1,5 @@
 package com.leets.commitatobe.domain.commit.service;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -14,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -49,7 +44,7 @@ public class GitHubService {
 	private String SERVER_URI;
 
 	// GitHub repository 이름 저장
-	public List<String> fetchRepos(String gitHubUsername) throws IOException {
+	public List<String> fetchRepos(String gitHubUsername) {
 		JsonArray repos = getConnection("/user/repos?type=all&sort=pushed&per_page=100");
 
 		if (repos == null) {
@@ -66,7 +61,7 @@ public class GitHubService {
 		return forkJoinPool.submit(() ->
 			repoFullNames.parallelStream()
 				.filter(fullName -> isContributor(fullName, gitHubUsername))
-				.collect(Collectors.toList())
+				.toList()
 		).join();
 	}
 
@@ -157,32 +152,6 @@ public class GitHubService {
 			.map(res -> JsonParser.parseString(res).getAsJsonArray());
 
 		return response.block();
-	}
-
-	// 응답을 jsonObject로 반환
-	private JsonObject fetchJsonObject(HttpURLConnection connection) throws IOException {
-		int responseCode = connection.getResponseCode();
-		if (responseCode == HttpURLConnection.HTTP_OK) {
-			try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
-				return JsonParser.parseReader(in).getAsJsonObject();
-			}
-		} else {
-			System.err.println(responseCode);
-			return null;
-		}
-	}
-
-	// 응답을 JsonArray로 반환
-	private JsonArray fetchJsonArray(HttpURLConnection connection) throws IOException {
-		int responseCode = connection.getResponseCode();
-		if (responseCode == HttpURLConnection.HTTP_OK) {
-			try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
-				return JsonParser.parseReader(in).getAsJsonArray();
-			}
-		} else {
-			System.err.println(responseCode);
-			return null;
-		}
 	}
 
 	// commit 시간 추출

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -101,7 +101,7 @@ public class GitHubService {
 		while (true) {
 			JsonArray commits;
 
-			try{
+			try {
 				commits = getConnection("/repos/" + fullName + "/commits?page=" + page + "&per_page=100");
 			} catch (Exception e) {
 				return;

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -11,11 +11,12 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        use_sql_comments: true
+        format_sql: false
+        use_sql_comments: false
+        show_sql: false
     defer-datasource-initialization: true
 
   sql:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -11,11 +11,12 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        use_sql_comments: true
+        format_sql: false
+        use_sql_comments: false
+        show_sql: false
     defer-datasource-initialization: true
 
   sql:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
GitHub API 통신 방식을 HttpUrlConnection에서 WebClient으로 변경합니다.
이를 통해 해당 API 통신 시간을 18553ms에서 11535ms로 단축하여, 약 37.83%의 성능 향상을 이뤘습니다.

---

## 🔗 관련 이슈
- close #43

---

## 💡 추가 사항
1. `Webclient`에서 최대로 전달할 수 있는 데이터의 크기보다 API에서 통신하는 양이 더 많아 최대로 전달할 수 있는 데이터의 크기를 1MB로 확장했는데, 최대 용량에 대한 의견을 주셨으면 좋겠습니다.
2. GitHub API의 통신방식을 변경하던 중, private repository를 받지 못하는 문제를 발견하여, 다음과 같은 해결 방법을 찾았습니다. 이에 대한 의견도 부탁드립니다! 아래에 해결 방법과 장/단점을 알려드리겠습니다.
 - GitHub APP 방식으로 진행 (현행)
   - 해당 방식으로 진행하게 된다면, 추가적인 권한 없이 public repo를 조회할 수 있지만, private repository에 접근하기 위해 GitHub APP을 설치해야 한다는 점을 고지해야합니다. 또한 organization에도 해당 APP을 설치해야 저희가 private repository에 대한 접근 권한을 가져올 수 있습니다.
  - OAuth APP 방식으로 진행
    - 해당 방식으로 진행하게 된다면, organization의 public repo를 조회하기 위해서는 해당 APP에 권한을 부여해야합니다. OAuth 로그인을 할 때, 권한을 부여할 수 있지만, organization 관리자에게 읽기 권한을 받아야하는 단점이 있습니다.
