### PR TITLE
bug: 경험치 최신화 시 정확하게 값이 계산되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -25,10 +25,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import reactor.core.publisher.Mono;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
@@ -51,6 +50,8 @@ public class GitHubService {
 
 	// GitHub repository 이름 저장
 	public List<String> fetchRepos(String gitHubUsername) {
+		commitsByDate.clear();
+
 		Set<String> repoFullNames = new HashSet<>();
 
 		JsonArray repos = getConnection("/user/repos?type=all&sort=pushed&per_page=100");

--- a/src/main/java/com/leets/commitatobe/global/jwt/dto/JwtResponse.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/dto/JwtResponse.java
@@ -1,6 +1,7 @@
 package com.leets.commitatobe.global.jwt.dto;
 
 public record JwtResponse(
+	String githubId,
 	String grantType,
 	String accessToken
 ) {

--- a/src/main/java/com/leets/commitatobe/global/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/provider/JwtProvider.java
@@ -40,7 +40,7 @@ public class JwtProvider {
 	// AccessToken을 생성하는 메서드
 	public JwtResponse generateTokenDto(String githubId) {
 		String accessToken = generateAccessToken(githubId);
-		return new JwtResponse("bearer", accessToken);
+		return new JwtResponse(githubId, "bearer", accessToken);
 	}
 
 	// Access Token 생성


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- 경험치 최신화 시 정확하게 값이 계산될 수 있도록 commitsByDate를 초기화하도록 수정
- 다음 사진과 같이 커밋기록이 중첩되지 않고 경험치가 계산이 되는 것을 확인할 수 있음
![image](https://github.com/user-attachments/assets/31986075-51ca-4d88-98c3-62d49edd5f8c)


---

## 🔗 관련 이슈
- close #47 

---

## 💡 추가 사항
- 프론트측의 요청사항으로 로그인 시 response값에 githubId도 받아올 수 있도록 수정하였습니다.
![image](https://github.com/user-attachments/assets/53eef537-a27b-4092-9359-1b53ff85cb2e)

