### PR TITLE
performance: GitHub API 통신 시간 단축

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -43,16 +43,12 @@ public class FetchCommits {
 		}
 
 		try {
-			// 기존: Github API Access Token 저장
-			//            gitHubService.updateToken(loginCommandService.gitHubLogin(gitHubId));
-
-			//변경: DB에서 엑세스 토큰 불러오도록 방식 변경
 			gitHubService.updateToken(userQueryService.getUserGitHubAccessToken(gitHubId));
 
 			List<String> repos = gitHubService.fetchRepos(gitHubId);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
-			LocalDateTime finalDateTime = dateTime; // 오류 방지
+			LocalDateTime finalDateTime = dateTime.toLocalDate().atStartOfDay();
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
@@ -49,7 +49,7 @@ public class FetchCommitsTest {
 			List<String> repos = gitHubService.fetchRepos(gitHubId);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
-			LocalDateTime finalDateTime = dateTime; // 오류 방지
+			LocalDateTime finalDateTime = dateTime.toLocalDate().atStartOfDay();
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -107,7 +107,9 @@ public class GitHubService {
 			JsonArray commits;
 
 			try {
-				commits = getConnection("/repos/" + fullName + "/commits?page=" + page + "&per_page=100");
+				commits = getConnection(
+					"/repos/" + fullName + "/commits?page=" + page + "&per_page=100" + "&since=" + formatToISO8601(
+						date));
 			} catch (Exception e) {
 				return;
 			}
@@ -168,7 +170,7 @@ public class GitHubService {
 	private boolean validateAuthor(JsonObject commitJson, String gitHubUsername) {
 		if (commitJson.has("author") && !commitJson.get("author").isJsonNull()) {
 			JsonElement topAuthor = commitJson.getAsJsonObject("author").get("login");
-			if (topAuthor!=null && !topAuthor.isJsonNull()) {
+			if (topAuthor != null && !topAuthor.isJsonNull()) {
 				return topAuthor.getAsString().equals(gitHubUsername);
 			}
 		}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- [x] GitHub API에 날짜 쿼리 추가로 수신 범위 수정
### TO-BE
`Duration in milliseconds: 11433`
### AS-IS
`Duration in milliseconds: 5890`

약 `48.47%`의 성능 향상

---

## 🔗 관련 이슈
- close #59

---

## 💡 추가 사항

