### PR TITLE
bug: ElasticSearch 7.17.10 버전으로 다운그레이드

### DIFF
--- a/src/main/java/com/leets/commitatobe/global/config/elastic/ElasticSearchConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/elastic/ElasticSearchConfig.java
@@ -1,57 +1,20 @@
 package com.leets.commitatobe.global.config.elastic;
 
-import javax.net.ssl.SSLContext;
-
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 
 @Configuration
-public class ElasticSearchConfig {
-
-	@Value("${spring.elasticsearch.username}")
-	private String username;
-
-	@Value("${spring.elasticsearch.password}")
-	private String password;
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
 
 	@Value("${hostname}")
 	private String hostname;
 
-	@Bean
-	public ElasticsearchClient elasticSearchClient() {
-		SSLContext sslContext;
-		try {
-			sslContext = SSLContextBuilder.create()
-				.loadTrustMaterial(null, (certificate, authType) -> true)
-				.build();
-		} catch (Exception e) {
-			throw new RuntimeException("SSLContext 구성 실패", e);
-		}
-
-		BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-		credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
-
-		RestClient restClient = RestClient.builder(
-				new HttpHost(hostname, 9200, "https"))
-			.setHttpClientConfigCallback(httpClientBuilder ->
-				httpClientBuilder.setSSLContext(sslContext)
-					.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-					.setDefaultCredentialsProvider(credentialsProvider)
-			).build();
-
-		RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
-		return new ElasticsearchClient(transport);
+	@Override
+	public ClientConfiguration clientConfiguration() {
+		return ClientConfiguration.builder()
+			.connectedTo(hostname)
+			.build();
 	}
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,8 +1,6 @@
 spring:
   elasticsearch:
-    uris: ENC(vCq/Pi+4NJNk4T8LEj3TIh6y9qWOfUaIy0X5uw8TlHvgZ6acP73xvA==)
-    username: ENC(+9CIeQ6TE+PYzeZegK9etg==)
-    password: ENC(M1dikxwEY3KyLOq/TyYphDmGflvs4+Ud)
+    uris: ENC(Tih31B4mNPq4id5pcOw5GB0IqNlajDwiwLE4IGP5sPAnD4NzdqhZJw==)
   application:
     name: commitato-BE
 
@@ -60,4 +58,4 @@ management:
 
 server-uri: ENC(9uSGkzaRV41gMgfy74TVxkbrDYtD0CuIDFSRJuQba14hudMDsWXVhw==)
 
-hostname: ENC(5H01n5YFZSpX7RchqwfV1yMJ4aRIhyXg)
+hostname: ENC(gHEhGUxcT6N2x/YrCy7fvAcAmYnn5xiOuXXqPJG9YgA=)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,8 +1,6 @@
 spring:
   elasticsearch:
-    uris: https://localhost:9200
-    username: ${ES_USER}
-    password: ${ES_PASSWORD}
+    uris: http://localhost:9200
   application:
     name: commitato-BE
 
@@ -59,4 +57,4 @@ management:
 
 server-uri: http://localhost:8080
 
-hostname: localhost
+hostname: ENC(KGCaSctauQhQQgsDzQiSY6qqFEn7ANxV)

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,8 +1,6 @@
 spring:
   elasticsearch:
-    uris: ENC(yjxpNLodc4kfbVbovB02fp06PZXt+4vdVoCY4FdbuW3UGAYvF50GqQ==)
-    username: ENC(2XtFu7UpaRzMBGFkOM5LQg==)
-    password: ENC(oJLvll8ubCRYLUZXVJzFxc/siceJ2OGA)
+    uris: ENC(c4D0381DRDiy6fOYvGdITd7tcIKeXOaybB0UnUU6UQPfHbQ7hUqlkA==)
   application:
     name: commitato-BE
 
@@ -60,4 +58,4 @@ management:
 
 server-uri: ENC(ugcPjCCqPIKcaBDy9haOfZilhoZ/l2WM1vpO5WjxC2CSIgYPy6s/KQ==)
 
-hostname: ENC(8xM3quuM8SRP+x7PJ0QQdIHcJP6LaPXZ)
+hostname: ENC(3CKjsUB/j+kYs1Wd0T4IdMqCPbbHBGNXs+/SnY3XThc=)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**- ElasticSearch의 버전을 7.17.10으로 변경하였고 이에 따른 보안 설정을 수정하였습니다.**
- username, password의 필요가 없어졌기에 삭제하였고 https를 http로 수정하였습니다.
- 현재 local에서 문제없이 작동하는 것을 확인하였습니다. 
![image](https://github.com/user-attachments/assets/0ed0da9d-012e-452e-a621-71470b7f5fc9)



---

## 🔗 관련 이슈
- close #72 

---

## 💡 추가 사항
ElasticSearch를 7.17.10버전으로 다운로드해주시면 끝납니다. kibana도 혹시 사용 예정이시면 동일하게 7.17.10을 다운 받아주시면 됩니다.
