### PR TITLE
feat: 경험치 입력 시 사용자의 경험치 및 티어를 경험치에 맞게 수정하는 api 구현

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/controller/ExpAndTierTestController.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/controller/ExpAndTierTestController.java
@@ -1,0 +1,30 @@
+package com.leets.commitatobe.domain.commit.controller;
+
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.leets.commitatobe.domain.commit.dto.response.ExpAndTierResponse;
+import com.leets.commitatobe.domain.commit.service.ExpService;
+import com.leets.commitatobe.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Exp, Tier 업데이트 컨트롤러", description = "입력한 Exp에 따른 사용자의 Exp와 Tier 데이터 가공을 처리합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/update/exp-tier")
+public class ExpAndTierTestController {
+	private final ExpService expService;
+
+	@Operation(
+		summary = "경험치 및 티어 업데이트",
+		description = "테스트를 위해, 사용자가 경험치 입력 시 경험치와 티어를 해당 경험치에 맞게 업데이트합니다.")
+	@PatchMapping("update/expAndTier")
+	public ApiResponse<ExpAndTierResponse> updateExpAndTier(@RequestParam("exp") int exp) {
+		return ApiResponse.onSuccess(expService.updateExpAndTier(exp));
+	}
+}

--- a/src/main/java/com/leets/commitatobe/domain/commit/controller/ExpAndTierTestController.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/controller/ExpAndTierTestController.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Exp, Tier 업데이트 컨트롤러", description = "입력한 Exp에 따른 사용자의 Exp와 Tier 데이터 가공을 처리합니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/update/exp-tier")
+@RequestMapping
 public class ExpAndTierTestController {
 	private final ExpService expService;
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/controller/ExpAndTierTestController.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/controller/ExpAndTierTestController.java
@@ -16,14 +16,14 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Exp, Tier 업데이트 컨트롤러", description = "입력한 Exp에 따른 사용자의 Exp와 Tier 데이터 가공을 처리합니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping
+@RequestMapping("user/update")
 public class ExpAndTierTestController {
 	private final ExpService expService;
 
 	@Operation(
 		summary = "경험치 및 티어 업데이트",
 		description = "테스트를 위해, 사용자가 경험치 입력 시 경험치와 티어를 해당 경험치에 맞게 업데이트합니다.")
-	@PatchMapping("update/expAndTier")
+	@PatchMapping("/exp-tier")
 	public ApiResponse<ExpAndTierResponse> updateExpAndTier(@RequestParam("exp") int exp) {
 		return ApiResponse.onSuccess(expService.updateExpAndTier(exp));
 	}

--- a/src/main/java/com/leets/commitatobe/domain/commit/dto/response/ExpAndTierResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/dto/response/ExpAndTierResponse.java
@@ -1,0 +1,19 @@
+package com.leets.commitatobe.domain.commit.dto.response;
+
+import com.leets.commitatobe.domain.user.domain.User;
+
+public record ExpAndTierResponse(
+	String id,
+	String githubId,
+	String tierName,
+	Integer exp
+) {
+	public static ExpAndTierResponse from(User user) {
+		return new ExpAndTierResponse(
+			user.getId().toString(),
+			user.getGithubId(),
+			user.getTier().getTierName(),
+			user.getExp()
+		);
+	}
+}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -125,7 +125,7 @@ public class ExpService {
 			.orElseThrow(() -> new ApiException(ErrorStatus._TIER_NOT_FOUND));
 	}
 
-	public ExpAndTierResponse updateExpAndTier(int exp){
+	public ExpAndTierResponse updateExpAndTier(int exp) {
 		String gitHubId = loginQueryService.getGitHubId();
 		User user = userRepository.findByGithubId(gitHubId)
 			.orElseThrow(() -> new ApiException(_USER_NOT_FOUND));

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -1,5 +1,7 @@
 package com.leets.commitatobe.domain.commit.service;
 
+import static com.leets.commitatobe.global.response.code.status.ErrorStatus.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -10,7 +12,9 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.leets.commitatobe.domain.commit.domain.Commit;
+import com.leets.commitatobe.domain.commit.dto.response.ExpAndTierResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
+import com.leets.commitatobe.domain.login.service.LoginQueryService;
 import com.leets.commitatobe.domain.tier.domain.Tier;
 import com.leets.commitatobe.domain.tier.repository.TierRepository;
 import com.leets.commitatobe.domain.user.domain.User;
@@ -28,6 +32,7 @@ public class ExpService {
 	private final CommitRepository commitRepository;
 	private final UserRepository userRepository;
 	private final TierRepository tierRepository;
+	private final LoginQueryService loginQueryService;
 
 	private static final int DAILY_BONUS_EXP = 100;
 	private static final int BONUS_EXP_INCREASE = 10;
@@ -118,5 +123,17 @@ public class ExpService {
 			.filter(tier -> tier.isValid(exp))
 			.max(Comparator.comparing(Tier::getRequiredExp))
 			.orElseThrow(() -> new ApiException(ErrorStatus._TIER_NOT_FOUND));
+	}
+
+	public ExpAndTierResponse updateExpAndTier(int exp){
+		String gitHubId = loginQueryService.getGitHubId();
+		User user = userRepository.findByGithubId(gitHubId)
+			.orElseThrow(() -> new ApiException(_USER_NOT_FOUND));
+
+		user.updateExp(exp);
+		Tier tier = determineTier(exp);
+		user.updateTier(tier);
+
+		return ExpAndTierResponse.from(user);
 	}
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**- 특정 경험치 입력 시 사용자의 경험치를 입력한 경험치에 맞게 수정하고 티어 또한 경험치에 맞게 수정되도록 구현하였습니다.**
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/aa62dbaa-35d1-4acf-a840-f6051dad854c" />

다음과 같이 입력시 

<img width="448" alt="image" src="https://github.com/user-attachments/assets/d313adf9-a15c-4c81-a204-0dc337bbc69c" />

경험치와 티어가 변경되는 것을 확인할 수 있습니다.

---

## 🔗 관련 이슈
- close #74 

---

## 💡 추가 사항

