### PR TITLE
feat: 소셜 로그인 시, 최초 회원가입 구별 로직 추가

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.leets.commitatobe.domain.auth.dto.GitHubDto;
+import com.leets.commitatobe.domain.auth.dto.LoginResponse;
 import com.leets.commitatobe.domain.auth.service.AuthService;
 import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
@@ -53,16 +54,14 @@ public class AuthController {
 		example = "123456"
 	)
 	@GetMapping("/callback")
-	public ApiResponse<JwtResponse> githubCallback(@RequestParam("code") String code, HttpServletResponse response) {
-		// GitHub에서 받은 인가 코드로 액세스 토큰 요청
+	public ApiResponse<LoginResponse> githubCallback(@RequestParam("code") String code, HttpServletResponse response) {
 		String gitHubAccessToken = authService.gitHubLogin(code);
-		// 액세스 토큰을 이용하여 JWT 생성
-		JwtResponse jwt = customOAuth2UserService.generateJwt(gitHubAccessToken);
 
-		// 액세스 토큰을 헤더에 설정
-		response.setHeader("Authentication", "Bearer " + jwt.accessToken());
+		LoginResponse loginResponse = customOAuth2UserService.generateJwt(gitHubAccessToken);
 
-		return ApiResponse.onSuccess(jwt);
+		response.setHeader("Authentication", "Bearer " + loginResponse.jwtResponse().accessToken());
+
+		return ApiResponse.onSuccess(loginResponse);
 	}
 
 	// 사용자 로그인 및 github 엑세스 토큰이 잘 받아와지는지 확인하는 테스트 api

--- a/src/main/java/com/leets/commitatobe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/controller/AuthController.java
@@ -1,13 +1,13 @@
-package com.leets.commitatobe.domain.login.controller;
+package com.leets.commitatobe.domain.auth.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.leets.commitatobe.domain.login.dto.GitHubDto;
-import com.leets.commitatobe.domain.login.service.LoginCommandService;
-import com.leets.commitatobe.domain.login.service.LoginQueryService;
+import com.leets.commitatobe.domain.auth.dto.GitHubDto;
+import com.leets.commitatobe.domain.auth.service.AuthService;
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
 import com.leets.commitatobe.global.jwt.dto.JwtResponse;
 import com.leets.commitatobe.global.jwt.service.CustomOAuth2UserService;
@@ -25,10 +25,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/login")
 @Slf4j
-public class LoginController {
+public class AuthController {
 
-	private final LoginCommandService loginCommandService;
-	private final LoginQueryService loginQueryService;
+	private final AuthService authService;
+	private final AuthQueryService authQueryService;
 	private final UserQueryService userQueryService;
 
 	private final CustomOAuth2UserService customOAuth2UserService;
@@ -39,7 +39,7 @@ public class LoginController {
 	)
 	@GetMapping("/github")
 	public void redirectToGitHub(HttpServletResponse response) {
-		loginCommandService.redirect(response);
+		authService.redirect(response);
 	}
 
 	@Operation(
@@ -55,7 +55,7 @@ public class LoginController {
 	@GetMapping("/callback")
 	public ApiResponse<JwtResponse> githubCallback(@RequestParam("code") String code, HttpServletResponse response) {
 		// GitHub에서 받은 인가 코드로 액세스 토큰 요청
-		String gitHubAccessToken = loginCommandService.gitHubLogin(code);
+		String gitHubAccessToken = authService.gitHubLogin(code);
 		// 액세스 토큰을 이용하여 JWT 생성
 		JwtResponse jwt = customOAuth2UserService.generateJwt(gitHubAccessToken);
 
@@ -68,7 +68,7 @@ public class LoginController {
 	// 사용자 로그인 및 github 엑세스 토큰이 잘 받아와지는지 확인하는 테스트 api
 	@GetMapping("/test")
 	public ApiResponse<GitHubDto> test() {
-		GitHubDto user = loginQueryService.getGitHubUser();
+		GitHubDto user = authQueryService.getGitHubUser();
 		String gitHubAccessToken = userQueryService.getUserGitHubAccessToken(user.userId());
 		log.info("깃허브 엑세스 토큰: {}", gitHubAccessToken);
 		return ApiResponse.onSuccess(user);

--- a/src/main/java/com/leets/commitatobe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/controller/AuthController.java
@@ -10,7 +10,6 @@ import com.leets.commitatobe.domain.auth.dto.LoginResponse;
 import com.leets.commitatobe.domain.auth.service.AuthService;
 import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
-import com.leets.commitatobe.global.jwt.dto.JwtResponse;
 import com.leets.commitatobe.global.jwt.service.CustomOAuth2UserService;
 import com.leets.commitatobe.global.response.ApiResponse;
 

--- a/src/main/java/com/leets/commitatobe/domain/auth/domain/CustomUserDetails.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/domain/CustomUserDetails.java
@@ -1,11 +1,11 @@
-package com.leets.commitatobe.domain.login.domain;
+package com.leets.commitatobe.domain.auth.domain;
 
 import java.util.Collection;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import com.leets.commitatobe.domain.login.dto.GitHubDto;
+import com.leets.commitatobe.domain.auth.dto.GitHubDto;
 
 import lombok.Getter;
 

--- a/src/main/java/com/leets/commitatobe/domain/auth/dto/GitHubDto.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/dto/GitHubDto.java
@@ -1,0 +1,6 @@
+package com.leets.commitatobe.domain.auth.dto;
+
+public record GitHubDto(
+	String userId
+) {
+}

--- a/src/main/java/com/leets/commitatobe/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.leets.commitatobe.domain.auth.dto;
+
+import com.leets.commitatobe.global.jwt.dto.JwtResponse;
+
+public record LoginResponse(
+	boolean isNewUser,
+	JwtResponse jwtResponse
+) {
+	public static LoginResponse of(boolean isNewUser, JwtResponse jwtResponse) {
+		return new LoginResponse(isNewUser, jwtResponse);
+	}
+}

--- a/src/main/java/com/leets/commitatobe/domain/auth/service/AuthQueryService.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/service/AuthQueryService.java
@@ -1,16 +1,16 @@
-package com.leets.commitatobe.domain.login.service;
+package com.leets.commitatobe.domain.auth.service;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
-import com.leets.commitatobe.domain.login.dto.GitHubDto;
+import com.leets.commitatobe.domain.auth.domain.CustomUserDetails;
+import com.leets.commitatobe.domain.auth.dto.GitHubDto;
 import com.leets.commitatobe.global.exception.ApiException;
 import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 @Service
-public class LoginQueryService {
+public class AuthQueryService {
 
 	public GitHubDto getGitHubUser() {
 		CustomUserDetails userDetails = getUserDetails();

--- a/src/main/java/com/leets/commitatobe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package com.leets.commitatobe.domain.login.service;
+package com.leets.commitatobe.domain.auth.service;
 
 import static ch.qos.logback.core.encoder.ByteArrayUtil.*;
 import static com.leets.commitatobe.global.response.code.status.ErrorStatus.*;
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class LoginCommandService {
+public class AuthService {
 
 	// 암호화 알고리즘
 	private final String ENCODING_ALGORITHM = "AES/CBC/PKCS5Padding";
@@ -57,7 +57,7 @@ public class LoginCommandService {
 			.build();
 
 		// GitHub 액세스 토큰 요청
-		String tokenRequestUrl = "/login/oauth/access_token" +
+		String tokenRequestUrl = "/auth/oauth/access_token" +
 			"?client_id=" + clientId +
 			"&client_secret=" + clientSecret +
 			"&code=" + authCode +

--- a/src/main/java/com/leets/commitatobe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/service/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
 			.build();
 
 		// GitHub 액세스 토큰 요청
-		String tokenRequestUrl = "/auth/oauth/access_token" +
+		String tokenRequestUrl = "/login/oauth/access_token" +
 			"?client_id=" + clientId +
 			"&client_secret=" + clientSecret +
 			"&code=" + authCode +

--- a/src/main/java/com/leets/commitatobe/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/leets/commitatobe/domain/auth/service/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.leets.commitatobe.domain.login.service;
+package com.leets.commitatobe.domain.auth.service;
 
 import java.util.Collections;
 
@@ -8,7 +8,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
+import com.leets.commitatobe.domain.auth.domain.CustomUserDetails;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.dto.response.ExpAndTierResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.login.service.LoginQueryService;
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.tier.domain.Tier;
 import com.leets.commitatobe.domain.tier.repository.TierRepository;
 import com.leets.commitatobe.domain.user.domain.User;
@@ -32,7 +32,7 @@ public class ExpService {
 	private final CommitRepository commitRepository;
 	private final UserRepository userRepository;
 	private final TierRepository tierRepository;
-	private final LoginQueryService loginQueryService;
+	private final AuthQueryService authQueryService;
 
 	private static final int DAILY_BONUS_EXP = 100;
 	private static final int BONUS_EXP_INCREASE = 10;
@@ -126,7 +126,7 @@ public class ExpService {
 	}
 
 	public ExpAndTierResponse updateExpAndTier(int exp) {
-		String gitHubId = loginQueryService.getGitHubId();
+		String gitHubId = authQueryService.getGitHubId();
 		User user = userRepository.findByGithubId(gitHubId)
 			.orElseThrow(() -> new ApiException(_USER_NOT_FOUND));
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.dto.response.CommitResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.login.service.LoginQueryService;
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
@@ -27,12 +27,12 @@ public class FetchCommits {
 	private final CommitRepository commitRepository;
 	private final UserRepository userRepository;
 	private final GitHubService gitHubService; // GitHub API 통신
-	private final LoginQueryService loginQueryService;
+	private final AuthQueryService authQueryService;
 	private final ExpService expService;
 	private final UserQueryService userQueryService;
 
 	public CommitResponse execute() {
-		String gitHubId = loginQueryService.getGitHubId();
+		String gitHubId = authQueryService.getGitHubId();
 		User user = userRepository.findByGithubId(gitHubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommitsTest.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.dto.response.CommitResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.login.service.LoginQueryService;
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
@@ -27,12 +27,12 @@ public class FetchCommitsTest {
 	private final CommitRepository commitRepository;
 	private final UserRepository userRepository;
 	private final GitHubService gitHubService; // GitHub API 통신
-	private final LoginQueryService loginQueryService;
+	private final AuthQueryService authQueryService;
 	private final ExpService expService;
 	private final UserQueryService userQueryService;
 
 	public CommitResponse execute() {
-		String gitHubId = loginQueryService.getGitHubId();
+		String gitHubId = authQueryService.getGitHubId();
 		User user = userRepository.findByGithubId(gitHubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -87,8 +87,8 @@ public class GitHubService {
 		for (int i = 0; i < contributors.size(); i++) {
 			JsonObject contributor = contributors.get(i).getAsJsonObject();
 
-			if (contributor.has("auth") && !contributor.get("auth").isJsonNull()) {
-				String contributorLogin = contributor.get("auth").getAsString();
+			if (contributor.has("login") && !contributor.get("login").isJsonNull()) {
+				String contributorLogin = contributor.get("login").getAsString();
 
 				if (contributorLogin.equals(gitHubUsername)) {
 					return true;
@@ -169,7 +169,7 @@ public class GitHubService {
 
 	private boolean validateAuthor(JsonObject commitJson, String gitHubUsername) {
 		if (commitJson.has("author") && !commitJson.get("author").isJsonNull()) {
-			JsonElement topAuthor = commitJson.getAsJsonObject("author").get("auth");
+			JsonElement topAuthor = commitJson.getAsJsonObject("author").get("login");
 			if (topAuthor != null && !topAuthor.isJsonNull()) {
 				return topAuthor.getAsString().equals(gitHubUsername);
 			}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -87,8 +87,8 @@ public class GitHubService {
 		for (int i = 0; i < contributors.size(); i++) {
 			JsonObject contributor = contributors.get(i).getAsJsonObject();
 
-			if (contributor.has("login") && !contributor.get("login").isJsonNull()) {
-				String contributorLogin = contributor.get("login").getAsString();
+			if (contributor.has("auth") && !contributor.get("auth").isJsonNull()) {
+				String contributorLogin = contributor.get("auth").getAsString();
 
 				if (contributorLogin.equals(gitHubUsername)) {
 					return true;
@@ -169,7 +169,7 @@ public class GitHubService {
 
 	private boolean validateAuthor(JsonObject commitJson, String gitHubUsername) {
 		if (commitJson.has("author") && !commitJson.get("author").isJsonNull()) {
-			JsonElement topAuthor = commitJson.getAsJsonObject("author").get("login");
+			JsonElement topAuthor = commitJson.getAsJsonObject("author").get("auth");
 			if (topAuthor != null && !topAuthor.isJsonNull()) {
 				return topAuthor.getAsString().equals(gitHubUsername);
 			}

--- a/src/main/java/com/leets/commitatobe/domain/login/dto/GitHubDto.java
+++ b/src/main/java/com/leets/commitatobe/domain/login/dto/GitHubDto.java
@@ -1,6 +1,0 @@
-package com.leets.commitatobe.domain.login.dto;
-
-public record GitHubDto(
-	String userId
-) {
-}

--- a/src/main/java/com/leets/commitatobe/domain/user/controller/UserController.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/controller/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.leets.commitatobe.domain.login.service.LoginQueryService;
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.domain.UserDocument;
 import com.leets.commitatobe.domain.user.dto.response.UserCommitResponse;
 import com.leets.commitatobe.domain.user.dto.response.UserInfoResponse;
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/user")
 public class UserController {
 	private final UserQueryService userQueryService;
-	private final LoginQueryService loginQueryService;
+	private final AuthQueryService authQueryService;
 
 	@Operation(
 		summary = "사용자 검색",
@@ -48,7 +48,7 @@ public class UserController {
 
 	@GetMapping("/{githubId}")
 	public ApiResponse<UserInfoResponse> getUserInfo(@PathVariable("githubId") String githubId) {
-		String myGitHubId = loginQueryService.getGitHubId();
+		String myGitHubId = authQueryService.getGitHubId();
 		return ApiResponse.onSuccess(userQueryService.findUserInfo(githubId, myGitHubId));
 	}
 

--- a/src/main/java/com/leets/commitatobe/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/service/UserQueryService.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.login.service.LoginCommandService;
+import com.leets.commitatobe.domain.auth.service.AuthService;
 import com.leets.commitatobe.domain.tier.domain.Tier;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.domain.UserDocument;
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class UserQueryService {
 	private final UserRepository userRepository;
 	private final CommitRepository commitRepository;
-	private final LoginCommandService loginCommandService;
+	private final AuthService authService;
 	private final UserSearchRepository userSearchRepository;
 
 	private User getUser(String githubId) {
@@ -104,7 +104,7 @@ public class UserQueryService {
 		User user = getUser(githubId);
 		String gitHubAccessToken = user.getGitHubAccessToken();
 
-		return loginCommandService.decrypt(gitHubAccessToken);
+		return authService.decrypt(gitHubAccessToken);
 	}
 
 	public UserInfoResponse findUserInfo(String githubId, String myGitHubId) {

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
 
 	private String[] getAuthWhitelist() {
 		return new String[] {
+			"/error",
 			"/v3/api-docs/**",
 			"/swagger-ui/**",
 			"/login/**",

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -36,9 +36,9 @@ public class SecurityConfig {
 		return new String[] {
 			"/v3/api-docs/**",
 			"/swagger-ui/**",
-			"/auth/**",
+			"/login/**",
 			actuatorEndPoint + "/**",
-			"/user/**",
+			"/user/**"
 		};
 	}
 

--- a/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
+++ b/src/main/java/com/leets/commitatobe/global/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 		return new String[] {
 			"/v3/api-docs/**",
 			"/swagger-ui/**",
-			"/login/**",
+			"/auth/**",
 			actuatorEndPoint + "/**",
 			"/user/**",
 		};

--- a/src/main/java/com/leets/commitatobe/global/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/provider/JwtProvider.java
@@ -13,7 +13,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import com.leets.commitatobe.domain.login.domain.CustomUserDetails;
+import com.leets.commitatobe.domain.auth.domain.CustomUserDetails;
 import com.leets.commitatobe.global.jwt.dto.JwtResponse;
 
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
@@ -56,7 +56,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			.tokenUri("https://github.com/login/oauth/access_token")
 			.authorizationUri("https://github.com/login/oauth/authorize")
 			.userInfoUri("https://api.github.com/user")
-			.userNameAttributeName("auth")  // GitHub의 로그인 이름 속성을 지정
+			.userNameAttributeName("login")  // GitHub의 로그인 이름 속성을 지정
 			.build();
 
 		OAuth2UserRequest userRequest = new OAuth2UserRequest(
@@ -74,14 +74,14 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		return new DefaultOAuth2User(
 			Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
 			oAuth2User.getAttributes(),
-			"auth");
+			"login");
 
 	}
 
 	public LoginResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws
 		OAuth2AuthenticationException {
 		OAuth2User oAuth2User = loadUser(userRequest);
-		String githubId = oAuth2User.getAttribute("auth");
+		String githubId = oAuth2User.getAttribute("login");
 
 		JwtResponse jwt = jwtProvider.generateTokenDto(githubId);
 
@@ -100,7 +100,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	}
 
 	private User createNewUser(OAuth2User oAuth2User) {
-		String githubId = oAuth2User.getAttribute("auth");
+		String githubId = oAuth2User.getAttribute("login");
 		String username = oAuth2User.getAttribute("name");
 		String profileImage = oAuth2User.getAttribute("avatar_url");
 

--- a/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.util.Pair;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -17,6 +18,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.leets.commitatobe.domain.auth.dto.LoginResponse;
 import com.leets.commitatobe.domain.auth.service.AuthService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
@@ -45,7 +47,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	@Autowired
 	private AuthService authService;
 
-	public JwtResponse generateJwt(String gitHubAccessToken) {
+	public LoginResponse generateJwt(String gitHubAccessToken) {
 		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("github")
 			.clientId(clientId)
 			.clientSecret(clientSecret)
@@ -76,21 +78,25 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	}
 
-	private JwtResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws
+	public LoginResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws
 		OAuth2AuthenticationException {
 		OAuth2User oAuth2User = loadUser(userRequest);
 		String githubId = oAuth2User.getAttribute("auth");
 
 		JwtResponse jwt = jwtProvider.generateTokenDto(githubId);
 
-		User user = userRepository.findByGithubId(githubId)
-			.orElseGet(() -> createNewUser(oAuth2User));
+		Pair<User, Boolean> userWithStatus = userRepository.findByGithubId(githubId)
+			.map(user -> Pair.of(user, false))
+			.orElseGet(() -> Pair.of(createNewUser(oAuth2User), true));
+
+		User user = userWithStatus.getFirst();
+		boolean isNewUser = userWithStatus.getSecond();
 
 		user.updateGitHubAccessToken(authService.encrypt(gitHubAccessToken));
 
 		userRepository.save(user);
 
-		return jwt;
+		return LoginResponse.of(isNewUser, jwt);
 	}
 
 	private User createNewUser(OAuth2User oAuth2User) {

--- a/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
@@ -76,7 +76,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	}
 
-	public JwtResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws
+	private JwtResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws
 		OAuth2AuthenticationException {
 		OAuth2User oAuth2User = loadUser(userRequest);
 		String githubId = oAuth2User.getAttribute("auth");
@@ -84,18 +84,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		JwtResponse jwt = jwtProvider.generateTokenDto(githubId);
 
 		User user = userRepository.findByGithubId(githubId)
-			.orElseGet(() -> createNewUser(oAuth2User, gitHubAccessToken));
+			.orElseGet(() -> createNewUser(oAuth2User));
 
-		String encryptedGitHubAccessToken = authService.encrypt(gitHubAccessToken);
-
-		user.updateGitHubAccessToken(encryptedGitHubAccessToken);
+		user.updateGitHubAccessToken(authService.encrypt(gitHubAccessToken));
 
 		userRepository.save(user);
 
 		return jwt;
 	}
 
-	public User createNewUser(OAuth2User oAuth2User, String gitHubAccessToken) {
+	private User createNewUser(OAuth2User oAuth2User) {
 		String githubId = oAuth2User.getAttribute("auth");
 		String username = oAuth2User.getAttribute("name");
 		String profileImage = oAuth2User.getAttribute("avatar_url");

--- a/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/leets/commitatobe/global/jwt/service/CustomOAuth2UserService.java
@@ -17,7 +17,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.leets.commitatobe.domain.login.service.LoginCommandService;
+import com.leets.commitatobe.domain.auth.service.AuthService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.global.jwt.dto.JwtResponse;
@@ -43,7 +43,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	private final UserRepository userRepository;
 
 	@Autowired
-	private LoginCommandService loginCommandService;
+	private AuthService authService;
 
 	public JwtResponse generateJwt(String gitHubAccessToken) {
 		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("github")
@@ -54,7 +54,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 			.tokenUri("https://github.com/login/oauth/access_token")
 			.authorizationUri("https://github.com/login/oauth/authorize")
 			.userInfoUri("https://api.github.com/user")
-			.userNameAttributeName("login")  // GitHub의 로그인 이름 속성을 지정
+			.userNameAttributeName("auth")  // GitHub의 로그인 이름 속성을 지정
 			.build();
 
 		OAuth2UserRequest userRequest = new OAuth2UserRequest(
@@ -72,21 +72,21 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		return new DefaultOAuth2User(
 			Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
 			oAuth2User.getAttributes(),
-			"login");
+			"auth");
 
 	}
 
 	public JwtResponse loadUserAndJwt(OAuth2UserRequest userRequest, String gitHubAccessToken) throws
 		OAuth2AuthenticationException {
 		OAuth2User oAuth2User = loadUser(userRequest);
-		String githubId = oAuth2User.getAttribute("login");
+		String githubId = oAuth2User.getAttribute("auth");
 
 		JwtResponse jwt = jwtProvider.generateTokenDto(githubId);
 
 		User user = userRepository.findByGithubId(githubId)
 			.orElseGet(() -> createNewUser(oAuth2User, gitHubAccessToken));
 
-		String encryptedGitHubAccessToken = loginCommandService.encrypt(gitHubAccessToken);
+		String encryptedGitHubAccessToken = authService.encrypt(gitHubAccessToken);
 
 		user.updateGitHubAccessToken(encryptedGitHubAccessToken);
 
@@ -96,7 +96,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 	}
 
 	public User createNewUser(OAuth2User oAuth2User, String gitHubAccessToken) {
-		String githubId = oAuth2User.getAttribute("login");
+		String githubId = oAuth2User.getAttribute("auth");
 		String username = oAuth2User.getAttribute("name");
 		String profileImage = oAuth2User.getAttribute("avatar_url");
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
- [x] `Login` 패키지 이름을 `Auth`로 변경
- [x] `/login` url이 비 정상적으로 리다이렉트가 많이 일어나는 오류 수정
- [x] 수정된 클래스 중 내부 로직의 한정자를 `private`로 변경 
- [x] 소셜 로그인 시, 최초 회원가입 구별 로직 추가
### 최초 로그인 시
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/b0b37b53-f39c-4165-b621-57d285e5cee4" />

### 최초 로그인이 아닐 시
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/4baff1b6-77ed-4a0f-b415-de884e895489" />

---

## 🔗 관련 이슈
- close #82

---

## 💡 추가 사항
- 추후에 로직 검토를 통해서 클래스 내부 로직은 `private`한정자를 붙여, 외부에서 접근을 막아야 할 것 같습니다!
