### PR TITLE
refactor: 랭킹 필드 재구현 및 랭킹 조회 로직 수정

### DIFF
--- a/src/main/java/com/leets/commitatobe/CommitatoBeApplication.java
+++ b/src/main/java/com/leets/commitatobe/CommitatoBeApplication.java
@@ -3,9 +3,11 @@ package com.leets.commitatobe;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class CommitatoBeApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(CommitatoBeApplication.class, args);

--- a/src/main/java/com/leets/commitatobe/domain/commit/dto/response/CommitResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/dto/response/CommitResponse.java
@@ -12,6 +12,7 @@ public record CommitResponse(
 	Boolean isMyAccount,
 	String githubId,
 	Integer exp,
+	Integer ranking,
 	String tierName,
 	String characterUrl,
 	Integer consecutiveCommitDays,
@@ -24,6 +25,7 @@ public record CommitResponse(
 			.isMyAccount(isMyAccount)
 			.githubId(user.getGithubId())
 			.exp(user.getExp())
+			.ranking(user.getRanking())
 			.tierName(user.getTier().getTierName())
 			.characterUrl(user.getTier().getCharacterUrl())
 			.consecutiveCommitDays(user.getConsecutiveCommitDays())

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -58,6 +58,9 @@ public class User extends BaseTimeEntity {
 	@Builder.Default
 	private Integer todayCommitCount = 0;
 
+	@Column
+	private Integer ranking;// 랭킹 추가
+
 	@ManyToOne
 	@JoinColumn(name = "tier_id")
 	private Tier tier;
@@ -83,6 +86,10 @@ public class User extends BaseTimeEntity {
 
 	public void updateTodayCommitCount(Integer todayCommitCount) {
 		this.todayCommitCount = todayCommitCount;
+	}
+
+	public void updateRank(Integer ranking) {
+		this.ranking = ranking;
 	}
 
 	public void updateLastCommitUpdateTime(LocalDateTime lastCommitUpdateTime) {

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/UserDocument.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/UserDocument.java
@@ -16,6 +16,7 @@ public class UserDocument {
 	private String id;
 	private String githubId;
 	private String tierName;
+	private Integer ranking;
 	private Integer exp;
 	private Integer consecutiveCommitDays;
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserInfoResponse.java
@@ -13,6 +13,7 @@ public record UserInfoResponse(
 	String githubId,
 	String githubUsername,
 	Integer exp,
+	Integer ranking,
 	String tierName,
 	String characterUrl,
 	Integer consecutiveCommitDays,
@@ -26,6 +27,7 @@ public record UserInfoResponse(
 			.githubId(user.getGithubId())
 			.githubUsername(user.getUsername())
 			.exp(user.getExp())
+			.ranking(user.getRanking())
 			.tierName(user.getTier().getTierName())
 			.characterUrl(user.getTier().getCharacterUrl())
 			.consecutiveCommitDays(user.getConsecutiveCommitDays())

--- a/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserRankResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserRankResponse.java
@@ -4,7 +4,6 @@ public record UserRankResponse(
 	String githubId,
 	Integer exp,
 	Integer consecutiveCommitDays,
-	String tierName,
-	Integer ranking
+	String tierName
 ) {
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserRankResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserRankResponse.java
@@ -4,6 +4,7 @@ public record UserRankResponse(
 	String githubId,
 	Integer exp,
 	Integer consecutiveCommitDays,
-	String tierName
+	String tierName,
+	Integer ranking
 ) {
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserSearchResponse.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/dto/response/UserSearchResponse.java
@@ -5,6 +5,7 @@ import com.leets.commitatobe.domain.user.domain.User;
 public record UserSearchResponse(
 	String id,
 	String githubId,
+	Integer ranking,
 	String tierName,
 	Integer exp,
 	Integer consecutiveCommitDays
@@ -15,6 +16,7 @@ public record UserSearchResponse(
 		return new UserSearchResponse(
 			user.getId().toString(),
 			user.getGithubId(),
+			user.getRanking(),
 			tierName,
 			user.getExp(),
 			user.getConsecutiveCommitDays()

--- a/src/main/java/com/leets/commitatobe/domain/user/service/RankingScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/service/RankingScheduler.java
@@ -1,0 +1,35 @@
+package com.leets.commitatobe.domain.user.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.commitatobe.domain.user.domain.User;
+import com.leets.commitatobe.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RankingScheduler {
+	private final UserRepository userRepository;
+
+	@Scheduled(cron = "0 30 0/3 * * *")
+	@Transactional
+	public void updateUserRankings() {
+		List<User> allUsers = userRepository.findAllByOrderByExpDesc(Pageable.unpaged()).getContent();
+
+		int ranking = 0;
+		int previousExp = -1;
+
+		for (User user : allUsers) {
+			if (!user.getExp().equals(previousExp)) {
+				ranking++;
+				previousExp = user.getExp();
+			}
+			user.updateRank(ranking);
+			userRepository.save(user);
+		}
+	}
+}

--- a/src/main/java/com/leets/commitatobe/domain/user/service/RankingScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/service/RankingScheduler.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.leets.commitatobe.domain.user.domain.User;
@@ -11,6 +12,7 @@ import com.leets.commitatobe.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Component
 @RequiredArgsConstructor
 public class RankingScheduler {
 	private final UserRepository userRepository;

--- a/src/main/java/com/leets/commitatobe/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/service/UserQueryService.java
@@ -84,8 +84,7 @@ public class UserQueryService {
 				user.getGithubId(),
 				user.getExp(),
 				user.getConsecutiveCommitDays(),
-				tier != null ? tier.getTierName() : "Unranked",
-				user.getRanking());//랭킹 추가
+				tier != null ? tier.getTierName() : "Unranked");
 		});
 
 		return CustomPageResponse.from(userRankResponses);

--- a/src/main/java/com/leets/commitatobe/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/service/UserQueryService.java
@@ -55,6 +55,7 @@ public class UserQueryService {
 				response.id(),
 				response.githubId(),
 				response.tierName(),
+				response.ranking(),
 				response.exp(),
 				response.consecutiveCommitDays()
 			);
@@ -83,7 +84,8 @@ public class UserQueryService {
 				user.getGithubId(),
 				user.getExp(),
 				user.getConsecutiveCommitDays(),
-				tier != null ? tier.getTierName() : "Unranked");//랭킹 추가
+				tier != null ? tier.getTierName() : "Unranked",
+				user.getRanking());//랭킹 추가
 		});
 
 		return CustomPageResponse.from(userRankResponses);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**- 랭킹 필드를 재생성하였습니다. 따라서 마이페이지 혹은 사용자 조회시 사용자의 랭킹이 보입니다.**
![image](https://github.com/user-attachments/assets/876b8e69-7d6d-4a28-8703-23f6761f06d1)
**- 하지만 랭킹 조회 기능을 수행하면 사용자의 랭킹은 보이지 않습니다.(이는 프론트에서 처리)**
![image](https://github.com/user-attachments/assets/fb47ebe4-fdad-4f1f-844f-939c9bff095c)

---

## 🔗 관련 이슈
- close #92 

---

## 💡 추가 사항

