### PR TITLE
feat: 커밋 기록 자동 업데이트 스케줄러 구현 및 커밋 기록 카운트 오류 수정

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -1,0 +1,61 @@
+package com.leets.commitatobe.domain.commit.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.commitatobe.domain.auth.service.AuthService;
+import com.leets.commitatobe.domain.commit.domain.Commit;
+import com.leets.commitatobe.domain.commit.repository.CommitRepository;
+import com.leets.commitatobe.domain.user.domain.User;
+import com.leets.commitatobe.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DailyCommitScheduler {
+	private final UserRepository userRepository;
+	private final GitHubService gitHubService;
+	private final CommitRepository commitRepository;
+	private final ExpService expService;
+	private final AuthService authService;
+
+	@Scheduled(cron = "0 10 23 * * *")
+	@Transactional
+	public void updateAllUsersCommits() {
+		List<User> users = userRepository.findAll();
+
+		for (User user : users) {
+			String token = authService.decrypt(user.getGitHubAccessToken());
+			gitHubService.updateToken(token);
+
+			LocalDateTime time = user.getLastCommitUpdateTime();
+			if (time == null) {
+				time = user.getCreatedAt().toLocalDate().atStartOfDay();
+			}
+
+			LocalDateTime since = time;
+			gitHubService.fetchRepos(user.getGithubId())
+				.forEach(name ->
+					gitHubService.countCommits(name, user.getGithubId(), since));
+
+			gitHubService.getCommitsByDate().forEach((date, cnt) -> {
+					Commit commit = commitRepository
+						.findByCommitDateAndUser(date, user)
+						.orElse(Commit.create(date, cnt, user));
+					commit.updateCnt(cnt);
+					commitRepository.save(commit);
+				}
+			);
+
+			user.updateLastCommitUpdateTime(LocalDateTime.now());
+			userRepository.save(user);
+
+			expService.calculateAndSaveExp(user.getGithubId());
+		}
+	}
+}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -24,7 +24,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final AuthService authService;
 
-	@Scheduled(cron = "0 55 23 * * *")
+	@Scheduled(cron = "0 15 23 * * *")
 	@Transactional
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAll();
@@ -38,7 +38,7 @@ public class DailyCommitScheduler {
 				time = user.getCreatedAt().toLocalDate().atStartOfDay();
 			}
 
-			LocalDateTime since = time;
+			LocalDateTime since = time.minusHours(9);
 			gitHubService.fetchRepos(user.getGithubId())
 				.forEach(name ->
 					gitHubService.countCommits(name, user.getGithubId(), since));

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -24,7 +24,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final AuthService authService;
 
-	@Scheduled(cron = "0 10 23 * * *")
+	@Scheduled(cron = "0 55 23 * * *")
 	@Transactional
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAll();

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -24,7 +24,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final AuthService authService;
 
-	@Scheduled(cron = "0 51 16 * * *")
+	@Scheduled(cron = "0 30 06 * * *")
 	@Transactional
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAll();

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -1,6 +1,21 @@
 package com.leets.commitatobe.domain.commit.service;
 
-/*@Component
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.commitatobe.domain.auth.service.AuthService;
+import com.leets.commitatobe.domain.commit.domain.Commit;
+import com.leets.commitatobe.domain.commit.repository.CommitRepository;
+import com.leets.commitatobe.domain.user.domain.User;
+import com.leets.commitatobe.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
 @RequiredArgsConstructor
 public class DailyCommitScheduler {
 	private final UserRepository userRepository;
@@ -9,7 +24,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final AuthService authService;
 
-	@Scheduled(cron = "0 05 00 * * *")
+	@Scheduled(cron = "0 51 16 * * *")
 	@Transactional
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAll();
@@ -31,8 +46,8 @@ public class DailyCommitScheduler {
 			gitHubService.getCommitsByDate().forEach((date, cnt) -> {
 					Commit commit = commitRepository
 						.findByCommitDateAndUser(date, user)
-						.orElse(Commit.create(date, cnt, user));
-					commit.updateCnt(cnt);
+						.orElse(Commit.create(date, 0, user));
+					commit.updateCnt(commit.getCnt() + cnt);
 					commitRepository.save(commit);
 				}
 			);
@@ -44,4 +59,3 @@ public class DailyCommitScheduler {
 		}
 	}
 }
-*/

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -1,21 +1,6 @@
 package com.leets.commitatobe.domain.commit.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.leets.commitatobe.domain.auth.service.AuthService;
-import com.leets.commitatobe.domain.commit.domain.Commit;
-import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.user.domain.User;
-import com.leets.commitatobe.domain.user.repository.UserRepository;
-
-import lombok.RequiredArgsConstructor;
-
-@Component
+/*@Component
 @RequiredArgsConstructor
 public class DailyCommitScheduler {
 	private final UserRepository userRepository;
@@ -24,7 +9,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final AuthService authService;
 
-	@Scheduled(cron = "0 15 23 * * *")
+	@Scheduled(cron = "0 05 00 * * *")
 	@Transactional
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAll();
@@ -59,3 +44,4 @@ public class DailyCommitScheduler {
 		}
 	}
 }
+*/

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -62,7 +62,7 @@ public class ExpService {
 
 		LocalDateTime today = LocalDate.now().atStartOfDay(); // 오늘 자정
 		LocalDateTime midnight = today.minusHours(9); // UTC와 KST 시간 차이를 맞추기 위함
-		int newCommitCount = commits.stream()
+		int todayCommitCount = commits.stream()
 			.filter(c -> !c.getCommitDate().isBefore(midnight))
 			.mapToInt(Commit::getCnt)
 			.sum();
@@ -80,7 +80,7 @@ public class ExpService {
 		user.updateTier(tier);
 		user.updateConsecutiveCommitDays(consecutiveDays);
 		user.updateTotalCommitCount(totalCommitCount);
-		user.updateTodayCommitCount(newCommitCount);
+		user.updateTodayCommitCount(todayCommitCount);
 
 		commitRepository.saveAll(commits);//변경된 커밋 정보 데이터베이스에 저장
 		userRepository.save(user);//변경된 사용자 정보 데이터베이스에 저장

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -7,14 +7,13 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.dto.response.ExpAndTierResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.tier.domain.Tier;
 import com.leets.commitatobe.domain.tier.repository.TierRepository;
 import com.leets.commitatobe.domain.user.domain.User;
@@ -64,14 +63,21 @@ public class ExpService {
 			lastCommitDate = commitDate;//마지막 커밋날짜를 현재 커밋날짜로 업데이트
 		}
 
-		if(!commits.isEmpty()){
+		LocalDateTime today = LocalDate.now().atStartOfDay();
+		LocalDateTime midnight = today.minusHours(9);
+		int newCommitCount = commits.stream()
+			.filter(c -> !c.getCommitDate().isBefore(midnight))
+			.mapToInt(Commit::getCnt)
+			.sum();
+
+		int todayCount = user.getTodayCommitCount() + newCommitCount;
+		/*if(!commits.isEmpty()){
 			Commit lastCommit = commits.get(commits.size() - 1);
 
 			if (lastCommit.getCommitDate().equals(LocalDateTime.now().toLocalDate().atStartOfDay())) {
 				todayCommitCount = lastCommit.getCnt(); //오늘 커밋 횟수 업데이트
 			}
-		}
-
+		}*/
 
 		if (lastCommitDate != null && lastCommitDate.isBefore(LocalDateTime.now().minusDays(1))) {
 			consecutiveDays = 0;//마지막 커밋날짜가 어제보다 이전이면 연속 커밋 일수 초기화
@@ -82,7 +88,7 @@ public class ExpService {
 		user.updateTier(tier);
 		user.updateConsecutiveCommitDays(consecutiveDays);
 		user.updateTotalCommitCount(totalCommitCount);
-		user.updateTodayCommitCount(todayCommitCount);
+		user.updateTodayCommitCount(todayCount);
 
 		commitRepository.saveAll(commits);//변경된 커밋 정보 데이터베이스에 저장
 		userRepository.save(user);//변경된 사용자 정보 데이터베이스에 저장

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -55,7 +55,6 @@ public class ExpService {
 			consecutiveDays = updateConsecutiveDays(lastCommitDate, commitDate, consecutiveDays);
 
 			totalExp += commit.calculateExp(DAILY_BONUS_EXP, consecutiveDays, BONUS_EXP_INCREASE);//총 경험치 업데이트
-			//			totalCommitCount += commit.getCnt();//총 커밋 횟수
 
 			commit.markAsCalculated();//커밋 계산 여부를 true로 해서 다음 게산에서 제외
 			lastCommitDate = commitDate;//마지막 커밋날짜를 현재 커밋날짜로 업데이트

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -44,8 +44,6 @@ public class ExpService {
 		int consecutiveDays = user.getConsecutiveCommitDays(); //연속 커밋 일수
 		LocalDateTime lastCommitDate = null; //마지막 커밋 날짜
 		int totalExp = user.getExp(); //사용자의 현재 경험치
-		int totalCommitCount = user.getTotalCommitCount(); //총 커밋 횟수
-		int todayCommitCount = 0;
 
 		for (Commit commit : commits) {//각 커밋을 반복해서 계산
 			if (commit.isCalculated()) {
@@ -57,27 +55,22 @@ public class ExpService {
 			consecutiveDays = updateConsecutiveDays(lastCommitDate, commitDate, consecutiveDays);
 
 			totalExp += commit.calculateExp(DAILY_BONUS_EXP, consecutiveDays, BONUS_EXP_INCREASE);//총 경험치 업데이트
-			totalCommitCount += commit.getCnt();//총 커밋 횟수
+			//			totalCommitCount += commit.getCnt();//총 커밋 횟수
 
 			commit.markAsCalculated();//커밋 계산 여부를 true로 해서 다음 게산에서 제외
 			lastCommitDate = commitDate;//마지막 커밋날짜를 현재 커밋날짜로 업데이트
 		}
 
-		LocalDateTime today = LocalDate.now().atStartOfDay();
-		LocalDateTime midnight = today.minusHours(9);
+		LocalDateTime today = LocalDate.now().atStartOfDay(); // 오늘 자정
+		LocalDateTime midnight = today.minusHours(9); // UTC와 KST 시간 차이를 맞추기 위함
 		int newCommitCount = commits.stream()
 			.filter(c -> !c.getCommitDate().isBefore(midnight))
 			.mapToInt(Commit::getCnt)
 			.sum();
 
-		int todayCount = user.getTodayCommitCount() + newCommitCount;
-		/*if(!commits.isEmpty()){
-			Commit lastCommit = commits.get(commits.size() - 1);
-
-			if (lastCommit.getCommitDate().equals(LocalDateTime.now().toLocalDate().atStartOfDay())) {
-				todayCommitCount = lastCommit.getCnt(); //오늘 커밋 횟수 업데이트
-			}
-		}*/
+		int totalCommitCount = commits.stream()
+			.mapToInt(Commit::getCnt)
+			.sum();
 
 		if (lastCommitDate != null && lastCommitDate.isBefore(LocalDateTime.now().minusDays(1))) {
 			consecutiveDays = 0;//마지막 커밋날짜가 어제보다 이전이면 연속 커밋 일수 초기화
@@ -88,7 +81,7 @@ public class ExpService {
 		user.updateTier(tier);
 		user.updateConsecutiveCommitDays(consecutiveDays);
 		user.updateTotalCommitCount(totalCommitCount);
-		user.updateTodayCommitCount(todayCount);
+		user.updateTodayCommitCount(newCommitCount);
 
 		commitRepository.saveAll(commits);//변경된 커밋 정보 데이터베이스에 저장
 		userRepository.save(user);//변경된 사용자 정보 데이터베이스에 저장

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -48,7 +48,7 @@ public class FetchCommits {
 			List<String> repos = gitHubService.fetchRepos(gitHubId);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
-			LocalDateTime finalDateTime = dateTime.minusHours(9);
+			LocalDateTime finalDateTime = dateTime.minusHours(9); //UTC와 KST 시간 차이를 맞추기 위함.
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
@@ -80,7 +80,7 @@ public class FetchCommits {
 		for (Map.Entry<LocalDateTime, Integer> entry : gitHubService.getCommitsByDate().entrySet()) {
 			Commit commit = commitRepository.findByCommitDateAndUser(entry.getKey(), user)
 				.orElse(Commit.create(entry.getKey(), 0, user));
-			commit.updateCnt(entry.getValue());
+			commit.updateCnt(entry.getValue() + commit.getCnt());
 			commitRepository.save(commit);
 		}
 	}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -11,10 +11,10 @@ import java.util.concurrent.Executors;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.dto.response.CommitResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
-import com.leets.commitatobe.domain.auth.service.AuthQueryService;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
@@ -48,7 +48,7 @@ public class FetchCommits {
 			List<String> repos = gitHubService.fetchRepos(gitHubId);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
-			LocalDateTime finalDateTime = dateTime.toLocalDate().atStartOfDay();
+			LocalDateTime finalDateTime = dateTime.minusHours(9);
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -17,7 +17,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -17,7 +17,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
**1일 1회 오전 06시 30분 사용자들의 커밋 기록을 자동으로 업데이트하는 스케줄러를 구현했습니다.**
- 기본 todayCommitCount=19, totalCommitCount=19인 상황에서 커밋 1회를 진행했습니다.
- 다음과 같이 커밋을 진행하고 스케줄러가 돌아갈 경우 제대로 todayCommitCount와 totalCommitCount가 반영된 것을 확인할 수 있습니다. 
<img width="609" height="294" alt="image" src="https://github.com/user-attachments/assets/47472666-bd52-4995-9a01-82230ca11fcc" />

- 그 후 다시 커밋을 진행하고 이번에는 수동 업데이트를 진행해도 제대로 반영이 되는 것을 확인할 수 있습니다.
<img width="605" height="272" alt="image" src="https://github.com/user-attachments/assets/57d24447-deed-4b79-827a-e56d2e53e7f9" />


---

## 🔗 관련 이슈
- close #96 

---

## 💡 추가 사항
- 현재 커밋 기록을 카운트하는 로직에서 중복 적용이 되는 오류가 존재하여 해당 오류를 해결했습니다. 
