### PR TITLE
Refactor/#112 깃허브 커밋 기록 및 경험치 계산 로직 성능 개선

### DIFF
--- a/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
@@ -41,7 +41,7 @@ public class Commit extends BaseTimeEntity {
 	private User user;
 
 	@Column(name = "is_calculated")
-	private boolean isCalculated;//경험치 계산 여부를 나타낸다.
+	private boolean calculated;//경험치 계산 여부를 나타낸다.
 
 	public static Commit create(LocalDateTime commitDate, Integer cnt, User user) {
 		return Commit.builder()
@@ -66,11 +66,11 @@ public class Commit extends BaseTimeEntity {
 	}
 
 	public void markAsCalculated() {
-		isCalculated = true;
+		calculated = true;
 	}
 
 	public void markAsUncalculated() {
-		isCalculated = false;
+		calculated = false;
 	}
 
 	public int calculateExp(int dailyBonusExp, int consecutiveDays, int bonusExpIncrease) {

--- a/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
@@ -42,17 +42,6 @@ public class Commit extends BaseTimeEntity {
 	@JsonBackReference
 	private User user;
 
-	@Column(name = "is_calculated")
-	private boolean calculated;//경험치 계산 여부를 나타낸다.
-
-	@Column(name = "calculated_count", nullable = false)
-	@Builder.Default
-	private Integer calculatedCount = 0;
-
-	@Column(name = "bonus_awarded", nullable = false)
-	@Builder.Default
-	private boolean bonusAwarded = false;
-
 	public static Commit create(LocalDateTime commitDate, Integer cnt, User user) {
 		return Commit.builder()
 			.commitDate(commitDate)
@@ -61,22 +50,7 @@ public class Commit extends BaseTimeEntity {
 			.build();
 	}
 
-	public void addCnt(int newCount) {
-		if (newCount <= 0) return;
-		this.cnt += newCount;
-		this.calculated = false; // 다시 계산 필요(단, delta만 계산할 거라 안전)
-	}
-
-	public int uncalculatedDelta() {
-		return Math.max(0, this.cnt - this.calculatedCount);
-	}
-
-	public void markAsCalculated() {
-		this.calculatedCount = this.cnt;
-		this.calculated = true;
-	}
-
-	public void todayBonusAwarded() {
-		this.bonusAwarded = true;
+	public void updateCnt(Integer newCnt) {
+		this.cnt = newCnt;
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
@@ -1,6 +1,5 @@
 package com.leets.commitatobe.domain.commit.domain;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -15,12 +14,15 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity(name = "commit")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class Commit extends BaseTimeEntity {
 
@@ -43,6 +45,14 @@ public class Commit extends BaseTimeEntity {
 	@Column(name = "is_calculated")
 	private boolean calculated;//경험치 계산 여부를 나타낸다.
 
+	@Column(name = "calculated_count", nullable = false)
+	@Builder.Default
+	private Integer calculatedCount = 0;
+
+	@Column(name = "bonus_awarded", nullable = false)
+	@Builder.Default
+	private boolean bonusAwarded = false;
+
 	public static Commit create(LocalDateTime commitDate, Integer cnt, User user) {
 		return Commit.builder()
 			.commitDate(commitDate)
@@ -51,34 +61,22 @@ public class Commit extends BaseTimeEntity {
 			.build();
 	}
 
-	@Builder
-	public Commit(LocalDateTime commitDate, Integer cnt, User user) {
-		this.commitDate = commitDate;
-		this.cnt = cnt;
-		this.user = user;
+	public void addCnt(int newCount) {
+		if (newCount <= 0) return;
+		this.cnt += newCount;
+		this.calculated = false; // 다시 계산 필요(단, delta만 계산할 거라 안전)
 	}
 
-	public void updateCnt(Integer cnt) {
-		if (!this.cnt.equals(cnt)) {
-			this.cnt = cnt;
-			markAsUncalculated();
-		}
+	public int uncalculatedDelta() {
+		return Math.max(0, this.cnt - this.calculatedCount);
 	}
 
 	public void markAsCalculated() {
-		calculated = true;
+		this.calculatedCount = this.cnt;
+		this.calculated = true;
 	}
 
-	public void markAsUncalculated() {
-		calculated = false;
-	}
-
-	public int calculateExp(int dailyBonusExp, int consecutiveDays, int bonusExpIncrease) {
-		int bonusExp = dailyBonusExp + (consecutiveDays - 1) * bonusExpIncrease;
-		return this.cnt * 5 + bonusExp;
-	}
-
-	public boolean commitDateIsToday() {
-		return this.commitDate.toLocalDate().isEqual(LocalDate.now());
+	public void todayBonusAwarded() {
+		this.bonusAwarded = true;
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
@@ -19,8 +19,8 @@ import lombok.*;
 @Entity(name = "commit")
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Commit extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/domain/Commit.java
@@ -14,15 +14,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity(name = "commit")
 @Getter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 public class Commit extends BaseTimeEntity {
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
@@ -17,6 +17,8 @@ public interface CommitRepository extends JpaRepository<Commit, UUID> {
 
 	Optional<Commit> findByCommitDateAndUser(LocalDateTime commitDate, User user);
 
+	Optional<Commit> findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(User user);
+
 	List<Commit> findAllByUserOrderByCommitDateAsc(User user);
 
 	@Query("SELECT c FROM commit c " +

--- a/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
@@ -13,13 +13,19 @@ import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.user.domain.User;
 
 public interface CommitRepository extends JpaRepository<Commit, UUID> {
-	List<Commit> findAllByUser(User user);
+	List<Commit> findAllByUserAndCalculatedFalse(User user);
 
-	Optional<Commit> findByCommitDateAndUser(LocalDateTime commitDate, User user);
+	List<Commit> findAllByUserAndCommitDate(User user, LocalDateTime commitDate);
 
 	Optional<Commit> findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(User user);
 
-	List<Commit> findAllByUserOrderByCommitDateAsc(User user);
+	Optional<Commit> findTopByUserOrderByCommitDateDesc(User user);
+
+	boolean existsByUserAndCommitDateAndCalculatedTrue(User user, LocalDateTime commitDate);
+
+	boolean existsByUserAndCommitDate(User user, LocalDateTime commitDate);
+
+	Optional<Commit> findTopByUserAndCalculatedTrueOrderByCommitDateDesc(User user);
 
 	@Query("SELECT c FROM commit c " +
 		"WHERE c.user = :user " +

--- a/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
@@ -15,17 +15,17 @@ import com.leets.commitatobe.domain.user.domain.User;
 public interface CommitRepository extends JpaRepository<Commit, UUID> {
 	List<Commit> findAllByUserAndCalculatedFalse(User user);
 
+	List<Commit> findAllByUserAndCalculatedFalseOrderByCommitDateAsc(User user);
+
 	List<Commit> findAllByUserAndCommitDate(User user, LocalDateTime commitDate);
 
 	Optional<Commit> findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(User user);
 
 	Optional<Commit> findTopByUserOrderByCommitDateDesc(User user);
 
-	boolean existsByUserAndCommitDateAndCalculatedTrue(User user, LocalDateTime commitDate);
+	Optional<Commit> findByUserAndCommitDate(User user, LocalDateTime commitDate);
 
 	boolean existsByUserAndCommitDate(User user, LocalDateTime commitDate);
-
-	Optional<Commit> findTopByUserAndCalculatedTrueOrderByCommitDateDesc(User user);
 
 	@Query("SELECT c FROM commit c " +
 		"WHERE c.user = :user " +

--- a/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
@@ -2,7 +2,6 @@ package com.leets.commitatobe.domain.commit.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,21 +12,12 @@ import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.user.domain.User;
 
 public interface CommitRepository extends JpaRepository<Commit, UUID> {
-	List<Commit> findAllByUserAndCalculatedFalseOrderByCommitDateAsc(User user);
+	List<Commit> findAllByUserAndCommitDateAfter(User user, LocalDateTime date);
 
-	List<Commit> findAllByUserAndCommitDate(User user, LocalDateTime commitDate);
-
-	List<Commit> findAllByUserAndCommitDateIn(User user, List<LocalDateTime> dates);
-
-	Optional<Commit> findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(User user);
-
-	Optional<Commit> findByUserAndCommitDate(User user, LocalDateTime commitDate);
+	boolean existsByUserAndCommitDate(User user, LocalDateTime commitDate);
 
 	@Query("SELECT c FROM commit c " +
 		"WHERE c.user = :user " +
 		"ORDER BY c.commitDate DESC")
 	List<Commit> findCommitsByUser(@Param("user") User user);
-
-	@Query("SELECT c.commitDate FROM commit c WHERE c.user = :user")
-	List<LocalDateTime> findAllCommitDatesByUser(@Param("user") User user);
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/repository/CommitRepository.java
@@ -13,22 +13,21 @@ import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.user.domain.User;
 
 public interface CommitRepository extends JpaRepository<Commit, UUID> {
-	List<Commit> findAllByUserAndCalculatedFalse(User user);
-
 	List<Commit> findAllByUserAndCalculatedFalseOrderByCommitDateAsc(User user);
 
 	List<Commit> findAllByUserAndCommitDate(User user, LocalDateTime commitDate);
 
+	List<Commit> findAllByUserAndCommitDateIn(User user, List<LocalDateTime> dates);
+
 	Optional<Commit> findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(User user);
 
-	Optional<Commit> findTopByUserOrderByCommitDateDesc(User user);
-
 	Optional<Commit> findByUserAndCommitDate(User user, LocalDateTime commitDate);
-
-	boolean existsByUserAndCommitDate(User user, LocalDateTime commitDate);
 
 	@Query("SELECT c FROM commit c " +
 		"WHERE c.user = :user " +
 		"ORDER BY c.commitDate DESC")
 	List<Commit> findCommitsByUser(@Param("user") User user);
+
+	@Query("SELECT c.commitDate FROM commit c WHERE c.user = :user")
+	List<LocalDateTime> findAllCommitDatesByUser(@Param("user") User user);
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -6,7 +6,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -73,10 +76,24 @@ public class CommitUpdateService {
 		LocalDateTime since = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
 
 		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
+		List<String> repos = gitHubService.fetchRepos(accessToken);
 
-		gitHubService.fetchRepos(accessToken)
-			.forEach(name ->
-				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
+		ExecutorService executor = Executors.newFixedThreadPool(
+			Math.min(repos.size(), Runtime.getRuntime().availableProcessors())
+		);
+
+		List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+		for (String fullName : repos) {
+			CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
+				gitHubService.countCommits(accessToken, fullName, user.getGithubId(), since, commitsByDate), executor
+			);
+			futures.add(future);
+		}
+
+		CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+		allFutures.join();
+		executor.shutdown();
 
 		saveCommits(user, commitsByDate, since);
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -5,16 +5,23 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.leets.commitatobe.domain.auth.dto.GithubToken;
+import com.leets.commitatobe.domain.auth.service.GithubTokenService;
 import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
+import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,11 +31,60 @@ public class CommitUpdateService {
 	private final UserRepository userRepository;
 	private final CommitRepository commitRepository;
 	private final ExpService expService;
+	private final GithubTokenService githubTokenService;
+	private final GitHubService gitHubService;
+
 
 	@Transactional
 	public void updateAndCalculate(UUID userId, Map<LocalDateTime, Integer> commitsByDate) {
 		User user = userRepository.getReferenceById(userId);
 		saveCommits(user, commitsByDate);
+		expService.calculateExpAndTier(user.getGithubId());
+	}
+
+	@Transactional
+	public void processHumanAccount(UUID userId) {
+		userRepository.findById(userId)
+			.ifPresent(User::changeHumanAccount);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void schedulerUpdateUserCommit(UUID userId) {
+		User user = userRepository.findById(userId).orElse(null);
+		if (user == null) return;
+
+		String accessToken = githubTokenService.getDecryptedAccessToken(user.getGithubId())
+			.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
+
+		try {
+			schedulerCommitUpdate(user, accessToken);
+		} catch (ApiException e) {
+			if (e.getErrorReasonHttpStatus().getHttpStatus() == HttpStatus.UNAUTHORIZED) {
+				GithubToken newToken = githubTokenService.updateAccessTokenByRefreshToken(user.getGithubId());
+				schedulerCommitUpdate(user, newToken.accessToken());
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	private void schedulerCommitUpdate(User user, String accessToken) {
+		LocalDateTime time = user.getLastCommitUpdateTime();
+		if (time == null) {
+			time = user.getCreatedAt().toLocalDate().atStartOfDay();
+		}
+		LocalDateTime since = time;
+
+		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
+
+		// GitHub API 호출 (여전히 네트워크 I/O지만, 상위에서 유저별로 병렬 실행 중)
+		gitHubService.fetchRepos(accessToken)
+			.forEach(name ->
+				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
+
+		saveCommits(user, commitsByDate);
+
+		// EXP 계산 (이미 최적화됨)
 		expService.calculateExpAndTier(user.getGithubId());
 	}
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -1,8 +1,12 @@
 package com.leets.commitatobe.domain.commit.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,17 +33,25 @@ public class CommitUpdateService {
 	}
 
 	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate) {
+		if (commitsByDate.isEmpty()) return;
+
+		List<LocalDateTime> dates = new ArrayList<>(commitsByDate.keySet());
+		List<Commit> existingCommits = commitRepository.findAllByUserAndCommitDateIn(user, dates);
+
+		Map<LocalDateTime, Commit> commitMap = existingCommits.stream()
+			.collect(Collectors.toMap(Commit::getCommitDate, Function.identity()));
+
+		List<Commit> toSave = new ArrayList<>();
+
 		commitsByDate.forEach((date, newCnt) -> {
-			if (newCnt == null || newCnt <= 0) {
-				return;
-			}
-
+			if (newCnt <= 0) return;
 			LocalDateTime day = date.toLocalDate().atStartOfDay();
-			Commit commit = commitRepository.findByUserAndCommitDate(user, day)
-				.orElseGet(() -> Commit.create(day, 0, user));
 
+			Commit commit = commitMap.getOrDefault(day, Commit.create(day, 0, user));
 			commit.addCnt(newCnt);
-			commitRepository.save(commit);
+			toSave.add(commit);
 		});
+
+		commitRepository.saveAll(toSave);
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -39,7 +39,7 @@ public class CommitUpdateService {
 
 		LocalDateTime since = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
 		saveCommits(user, commitsByDate, since);
-		expService.calculateExpAndTier(user.getGithubId());
+		expService.calculateExpAndTier(user);
 	}
 
 	@Transactional
@@ -80,7 +80,7 @@ public class CommitUpdateService {
 
 		saveCommits(user, commitsByDate, since);
 
-		expService.calculateExpAndTier(user.getGithubId());
+		expService.calculateExpAndTier(user);
 	}
 
 	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate, LocalDateTime since) {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -70,11 +70,7 @@ public class CommitUpdateService {
 	}
 
 	private void schedulerCommitUpdate(User user, String accessToken) {
-		LocalDateTime time = user.getLastCommitUpdateTime();
-		if (time == null) {
-			time = user.getCreatedAt().toLocalDate().atStartOfDay();
-		}
-		LocalDateTime since = time;
+		LocalDateTime since = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
 
 		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -1,13 +1,12 @@
 package com.leets.commitatobe.domain.commit.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -34,11 +33,12 @@ public class CommitUpdateService {
 	private final GithubTokenService githubTokenService;
 	private final GitHubService gitHubService;
 
-
 	@Transactional
 	public void updateAndCalculate(UUID userId, Map<LocalDateTime, Integer> commitsByDate) {
 		User user = userRepository.getReferenceById(userId);
-		saveCommits(user, commitsByDate);
+
+		LocalDateTime since = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
+		saveCommits(user, commitsByDate, since);
 		expService.calculateExpAndTier(user.getGithubId());
 	}
 
@@ -51,7 +51,8 @@ public class CommitUpdateService {
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void schedulerUpdateUserCommit(UUID userId) {
 		User user = userRepository.findById(userId).orElse(null);
-		if (user == null) return;
+		if (user == null)
+			return;
 
 		String accessToken = githubTokenService.getDecryptedAccessToken(user.getGithubId())
 			.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
@@ -77,37 +78,48 @@ public class CommitUpdateService {
 
 		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 
-		// GitHub API 호출 (여전히 네트워크 I/O지만, 상위에서 유저별로 병렬 실행 중)
 		gitHubService.fetchRepos(accessToken)
 			.forEach(name ->
 				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
 
-		saveCommits(user, commitsByDate);
+		saveCommits(user, commitsByDate, since);
 
-		// EXP 계산 (이미 최적화됨)
 		expService.calculateExpAndTier(user.getGithubId());
 	}
 
-	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate) {
-		if (commitsByDate.isEmpty()) return;
-
-		List<LocalDateTime> dates = new ArrayList<>(commitsByDate.keySet());
-		List<Commit> existingCommits = commitRepository.findAllByUserAndCommitDateIn(user, dates);
-
-		Map<LocalDateTime, Commit> commitMap = existingCommits.stream()
-			.collect(Collectors.toMap(Commit::getCommitDate, Function.identity()));
+	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate, LocalDateTime since) {
+		List<Commit> existingCommits = commitRepository.findAllByUserAndCommitDateAfter(user, since.minusSeconds(1));
 
 		List<Commit> toSave = new ArrayList<>();
+		List<Commit> toDelete = new ArrayList<>();
 
-		commitsByDate.forEach((date, newCnt) -> {
-			if (newCnt <= 0) return;
-			LocalDateTime day = date.toLocalDate().atStartOfDay();
+		for (Commit commit : existingCommits) {
+			LocalDateTime date = commit.getCommitDate();
 
-			Commit commit = commitMap.getOrDefault(day, Commit.create(day, 0, user));
-			commit.addCnt(newCnt);
-			toSave.add(commit);
+			if (commitsByDate.containsKey(date)) {
+				int newCnt = commitsByDate.get(date);
+				commit.updateCnt(newCnt);
+				commitsByDate.remove(date);
+			} else {
+				commit.updateCnt(0);
+			}
+
+			if (commit.getCnt() <= 0) {
+				toDelete.add(commit);
+			} else {
+				toSave.add(commit);
+			}
+		}
+
+		commitsByDate.forEach((date, cnt) -> {
+			if (cnt > 0) {
+				toSave.add(Commit.create(date, cnt, user));
+			}
 		});
 
+		if (!toDelete.isEmpty()) {
+			commitRepository.deleteAll(toDelete);
+		}
 		commitRepository.saveAll(toSave);
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.leets.commitatobe.global.config.redis.annotation.RedissonLock;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -36,10 +37,9 @@ public class CommitUpdateService {
 	private final GithubTokenService githubTokenService;
 	private final GitHubService gitHubService;
 
+	@RedissonLock(key = "#user.githubId")
 	@Transactional
-	public void updateAndCalculate(UUID userId, Map<LocalDateTime, Integer> commitsByDate) {
-		User user = userRepository.getReferenceById(userId);
-
+	public void updateAndCalculate(User user, Map<LocalDateTime, Integer> commitsByDate) {
 		LocalDateTime since = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
 		saveCommits(user, commitsByDate, since);
 		expService.calculateExpAndTier(user);

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/CommitUpdateService.java
@@ -1,0 +1,45 @@
+package com.leets.commitatobe.domain.commit.service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.leets.commitatobe.domain.commit.domain.Commit;
+import com.leets.commitatobe.domain.commit.repository.CommitRepository;
+import com.leets.commitatobe.domain.user.domain.User;
+import com.leets.commitatobe.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommitUpdateService {
+	private final UserRepository userRepository;
+	private final CommitRepository commitRepository;
+	private final ExpService expService;
+
+	@Transactional
+	public void updateAndCalculate(UUID userId, Map<LocalDateTime, Integer> commitsByDate) {
+		User user = userRepository.getReferenceById(userId);
+		saveCommits(user, commitsByDate);
+		expService.calculateExpAndTier(user.getGithubId());
+	}
+
+	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate) {
+		commitsByDate.forEach((date, newCnt) -> {
+			if (newCnt == null || newCnt <= 0) {
+				return;
+			}
+
+			LocalDateTime day = date.toLocalDate().atStartOfDay();
+			Commit commit = commitRepository.findByUserAndCommitDate(user, day)
+				.orElseGet(() -> Commit.create(day, 0, user));
+
+			commit.addCnt(newCnt);
+			commitRepository.save(commit);
+		});
+	}
+}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -2,10 +2,15 @@ package com.leets.commitatobe.domain.commit.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
 import com.leets.commitatobe.global.config.redis.annotation.RedissonLock;
+
 import org.springframework.transaction.annotation.Transactional;
 
 import com.leets.commitatobe.domain.auth.dto.GithubToken;
@@ -44,46 +49,50 @@ public class DailyCommitScheduler {
 				userRepository.save(user);
 				continue;
 			}
+
 			try {
 				tryCommitUpdate(user);
 			} catch (ApiException e) {
-				GithubToken newToken = githubTokenService.updateAccessTokenByRefreshToken(user.getGithubId());
-				gitHubService.updateToken(newToken.accessToken());
+				if (e.getErrorReasonHttpStatus().getHttpStatus() != HttpStatus.UNAUTHORIZED) {
+					throw e;
+				}
 
-				tryCommitUpdate(user);
+				GithubToken newToken = githubTokenService.updateAccessTokenByRefreshToken(user.getGithubId());
+				tryCommitUpdate(user, newToken.accessToken());
 			}
 		}
 	}
 
 	private void tryCommitUpdate(User user) {
-		gitHubService.runWithoutRedirect(() -> {
-			String token = githubTokenService.getDecryptedAccessToken(user.getGithubId())
-				.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
-			gitHubService.updateToken(token);
+		String accessToken = githubTokenService.getDecryptedAccessToken(user.getGithubId())
+			.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
+		tryCommitUpdate(user, accessToken);
+	}
 
-			LocalDateTime time = user.getLastCommitUpdateTime();
-			if (time == null) {
-				time = user.getCreatedAt().toLocalDate().atStartOfDay();
+	private void tryCommitUpdate(User user, String accessToken) {
+		LocalDateTime time = user.getLastCommitUpdateTime();
+		if (time == null) {
+			time = user.getCreatedAt().toLocalDate().atStartOfDay();
+		}
+
+		LocalDateTime since = time.minusHours(9);
+		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
+
+		gitHubService.fetchRepos(accessToken, user.getGithubId())
+			.forEach(name ->
+				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
+
+		commitsByDate.forEach((date, cnt) -> {
+				Commit commit = commitRepository.findByCommitDateAndUser(date, user)
+					.orElse(Commit.create(date, 0, user));
+				commit.updateCnt(commit.getCnt() + cnt);
+				commitRepository.save(commit);
 			}
+		);
 
-			LocalDateTime since = time.minusHours(9);
-			gitHubService.fetchRepos(user.getGithubId())
-				.forEach(name ->
-					gitHubService.countCommits(name, user.getGithubId(), since));
+		user.updateLastCommitUpdateTime(LocalDateTime.now());
+		userRepository.save(user);
 
-			gitHubService.getCommitsByDate().forEach((date, cnt) -> {
-					Commit commit = commitRepository
-						.findByCommitDateAndUser(date, user)
-						.orElse(Commit.create(date, 0, user));
-					commit.updateCnt(commit.getCnt() + cnt);
-					commitRepository.save(commit);
-				}
-			);
-
-			user.updateLastCommitUpdateTime(LocalDateTime.now());
-			userRepository.save(user);
-
-			expService.calculateAndSaveExp(user.getGithubId());
-		});
+		expService.calculateAndSaveExp(user.getGithubId());
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -1,93 +1,62 @@
 package com.leets.commitatobe.domain.commit.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.leets.commitatobe.global.config.redis.annotation.RedissonLock;
 
-import org.springframework.transaction.annotation.Transactional;
-
-import com.leets.commitatobe.domain.auth.dto.GithubToken;
-import com.leets.commitatobe.domain.auth.service.GithubTokenService;
-import com.leets.commitatobe.domain.commit.domain.Commit;
-import com.leets.commitatobe.domain.commit.repository.CommitRepository;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
-import com.leets.commitatobe.global.exception.ApiException;
-import com.leets.commitatobe.global.response.code.status.ErrorStatus;
+import com.leets.commitatobe.global.executor.LogExecutionTime;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class DailyCommitScheduler {
 	private static final long SIX_MONTHS = 6L;
 
 	private final UserRepository userRepository;
-	private final GitHubService gitHubService;
-	private final CommitRepository commitRepository;
-	private final ExpService expService;
-	private final GithubTokenService githubTokenService;
+	private final CommitUpdateService commitUpdateService;
 
-	@Scheduled(cron = "0 14 21 * * *", zone = "Asia/Seoul")
-	@Transactional
+	private final ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+	@Scheduled(cron = "0 04 13 * * *", zone = "Asia/Seoul")
 	@RedissonLock(key = "'commit-update-scheduler'", leaseTime = 600L)
+	@LogExecutionTime
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAllByIsHumanAccountFalse();
-
 		LocalDateTime afterHalfYear = LocalDateTime.now().minusMonths(SIX_MONTHS);
+
+		List<CompletableFuture<Void>> futures = new ArrayList<>();
 
 		for (User user : users) {
 			if (user.getLastLoginAt() != null && !user.getLastLoginAt().isAfter(afterHalfYear)) {
-				user.changeHumanAccount();
-				userRepository.save(user);
+				commitUpdateService.processHumanAccount(user.getId()); // 트랜잭션 분리
 				continue;
 			}
 
-			String accessToken = githubTokenService.getDecryptedAccessToken(user.getGithubId())
-				.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
-
-			try {
-				tryCommitUpdate(user, accessToken);
-			} catch (ApiException e) {
-				if (e.getErrorReasonHttpStatus().getHttpStatus() != HttpStatus.UNAUTHORIZED) {
-					throw e;
+			CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+				try {
+					commitUpdateService.schedulerUpdateUserCommit(user.getId());
+				} catch (Exception e) {
+					log.error("유저 {} 커밋 업데이트 실패", user.getGithubId(), e);
 				}
+			}, executorService);
 
-				GithubToken newToken = githubTokenService.updateAccessTokenByRefreshToken(user.getGithubId());
-				tryCommitUpdate(user, newToken.accessToken());
-			}
+			futures.add(future);
 		}
-	}
 
-	private void tryCommitUpdate(User user, String accessToken) {
-		LocalDateTime time = user.getLastCommitUpdateTime();
-		if (time == null) {
-			time = user.getCreatedAt().toLocalDate().atStartOfDay();
-		}
-		LocalDateTime since = time;
-
-		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
-
-		gitHubService.fetchRepos(accessToken)
-			.forEach(name ->
-				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
-
-		commitsByDate.forEach((date, delta) -> {
-			LocalDateTime day = date.toLocalDate().atStartOfDay();
-			Commit commit = commitRepository.findByUserAndCommitDate(user, day)
-				.orElseGet(() -> Commit.create(day, 0, user));
-
-			commit.addCnt(delta);
-			commitRepository.save(commit);
-		});
-
-		expService.calculateExpAndTier(user.getGithubId());
+		// 모든 작업이 끝날 때까지 대기
+		CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -30,7 +30,7 @@ public class DailyCommitScheduler {
 
 	private final ExecutorService executorService = Executors.newFixedThreadPool(10);
 
-	@Scheduled(cron = "0 04 13 * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 10 12 * * *", zone = "Asia/Seoul")
 	@RedissonLock(key = "'commit-update-scheduler'", leaseTime = 600L)
 	@LogExecutionTime
 	public void updateAllUsersCommits() {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -14,7 +14,6 @@ import com.leets.commitatobe.global.config.redis.annotation.RedissonLock;
 
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
-import com.leets.commitatobe.global.executor.LogExecutionTime;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +31,6 @@ public class DailyCommitScheduler {
 
 	@Scheduled(cron = "0 10 12 * * *", zone = "Asia/Seoul")
 	@RedissonLock(key = "'commit-update-scheduler'", leaseTime = 600L)
-	@LogExecutionTime
 	public void updateAllUsersCommits() {
 		List<User> users = userRepository.findAllByIsHumanAccountFalse();
 		LocalDateTime afterHalfYear = LocalDateTime.now().minusMonths(SIX_MONTHS);

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -35,7 +35,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final GithubTokenService githubTokenService;
 
-	@Scheduled(cron = "0 03 16 * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 14 21 * * *", zone = "Asia/Seoul")
 	@Transactional
 	@RedissonLock(key = "'commit-update-scheduler'", leaseTime = 600L)
 	public void updateAllUsersCommits() {
@@ -75,15 +75,18 @@ public class DailyCommitScheduler {
 
 		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 
-		gitHubService.fetchRepos(accessToken, user.getGithubId())
+		gitHubService.fetchRepos(accessToken)
 			.forEach(name ->
 				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
 
-		commitsByDate.forEach((date, cnt) -> {
-				LocalDateTime day = date.toLocalDate().atStartOfDay();
-				commitRepository.save(Commit.create(day, cnt, user));
-			}
-		);
+		commitsByDate.forEach((date, delta) -> {
+			LocalDateTime day = date.toLocalDate().atStartOfDay();
+			Commit commit = commitRepository.findByUserAndCommitDate(user, day)
+				.orElseGet(() -> Commit.create(day, 0, user));
+
+			commit.addCnt(delta);
+			commitRepository.save(commit);
+		});
 
 		expService.calculateExpAndTier(user.getGithubId());
 	}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -35,7 +35,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final GithubTokenService githubTokenService;
 
-	@Scheduled(cron = "0 59 19 * * *", zone = "Asia/Seoul")
+	@Scheduled(cron = "0 03 16 * * *", zone = "Asia/Seoul")
 	@Transactional
 	@RedissonLock(key = "'commit-update-scheduler'", leaseTime = 600L)
 	public void updateAllUsersCommits() {
@@ -85,9 +85,6 @@ public class DailyCommitScheduler {
 			}
 		);
 
-		user.updateLastCommitUpdateTime(LocalDateTime.now());
-		userRepository.save(user);
-
-		expService.calculateAndSaveExp(user.getGithubId());
+		expService.calculateExpAndTier(user.getGithubId());
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/DailyCommitScheduler.java
@@ -35,7 +35,7 @@ public class DailyCommitScheduler {
 	private final ExpService expService;
 	private final GithubTokenService githubTokenService;
 
-	@Scheduled(cron = "0 30 06 * * *")
+	@Scheduled(cron = "0 59 19 * * *", zone = "Asia/Seoul")
 	@Transactional
 	@RedissonLock(key = "'commit-update-scheduler'", leaseTime = 600L)
 	public void updateAllUsersCommits() {
@@ -50,8 +50,11 @@ public class DailyCommitScheduler {
 				continue;
 			}
 
+			String accessToken = githubTokenService.getDecryptedAccessToken(user.getGithubId())
+				.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
+
 			try {
-				tryCommitUpdate(user);
+				tryCommitUpdate(user, accessToken);
 			} catch (ApiException e) {
 				if (e.getErrorReasonHttpStatus().getHttpStatus() != HttpStatus.UNAUTHORIZED) {
 					throw e;
@@ -63,19 +66,13 @@ public class DailyCommitScheduler {
 		}
 	}
 
-	private void tryCommitUpdate(User user) {
-		String accessToken = githubTokenService.getDecryptedAccessToken(user.getGithubId())
-			.orElseThrow(() -> new ApiException(ErrorStatus._UNAUTHORIZED));
-		tryCommitUpdate(user, accessToken);
-	}
-
 	private void tryCommitUpdate(User user, String accessToken) {
 		LocalDateTime time = user.getLastCommitUpdateTime();
 		if (time == null) {
 			time = user.getCreatedAt().toLocalDate().atStartOfDay();
 		}
+		LocalDateTime since = time;
 
-		LocalDateTime since = time.minusHours(9);
 		Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 
 		gitHubService.fetchRepos(accessToken, user.getGithubId())
@@ -83,10 +80,8 @@ public class DailyCommitScheduler {
 				gitHubService.countCommits(accessToken, name, user.getGithubId(), since, commitsByDate));
 
 		commitsByDate.forEach((date, cnt) -> {
-				Commit commit = commitRepository.findByCommitDateAndUser(date, user)
-					.orElse(Commit.create(date, 0, user));
-				commit.updateCnt(commit.getCnt() + cnt);
-				commitRepository.save(commit);
+				LocalDateTime day = date.toLocalDate().atStartOfDay();
+				commitRepository.save(Commit.create(day, cnt, user));
 			}
 		);
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -42,15 +44,19 @@ public class ExpService {
 		User user = userRepository.findByGithubId(githubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + githubId));
 
-		int updatedConsecutiveDays = updateConsecutiveDays(user);
+		Set<LocalDate> commitDateSet = commitRepository.findAllCommitDatesByUser(user).stream()
+			.map(LocalDateTime::toLocalDate)
+			.collect(Collectors.toSet());
+
+		int updatedConsecutiveDays = updateConsecutiveDays(user, commitDateSet);
 
 		List<Commit> uncalculatedCommits = commitRepository.findAllByUserAndCalculatedFalseOrderByCommitDateAsc(user);
 		int baseExp = calculateBaseExp(uncalculatedCommits);
-		int bonusExp = calculateTodayBonusExp(user, uncalculatedCommits);
+		int bonusExp = calculateTodayBonusExp(uncalculatedCommits, commitDateSet);
 		int totalExp = user.getExp() + baseExp + bonusExp;
 
 		int todayCommitCount = todayCommitCount(user);
-		int totalCommitCount = totalCommitCount(user);
+		int totalCommitCount = totalCommitCount(user, uncalculatedCommits);
 
 		user.updateExp(totalExp);
 		user.updateTier(determineTier(totalExp));
@@ -64,40 +70,28 @@ public class ExpService {
 		userRepository.save(user);
 	}
 
-	private int updateConsecutiveDays(User user) {
-		LocalDateTime today = LocalDateTime.now().toLocalDate().atStartOfDay();
-		LocalDateTime yesterday = today.minusDays(1);
+	private int updateConsecutiveDays(User user, Set<LocalDate> commitDateSet) {
+		LocalDate today = LocalDate.now();
+		LocalDate yesterday = today.minusDays(1);
 
-		boolean hasTodayCommit = commitRepository.existsByUserAndCommitDate(user, today);
-		boolean hasYesterdayCommit = commitRepository.existsByUserAndCommitDate(user, yesterday);
+		boolean hasTodayCommit = commitDateSet.contains(today);
+		boolean hasYesterdayCommit = commitDateSet.contains(yesterday);
+
 		if (!hasTodayCommit && !hasYesterdayCommit) {
 			user.updateLastCommitDateAppliedDate(null);
 			return 0;
 		}
 
-		LocalDate recentCommitDay = commitRepository.findTopByUserOrderByCommitDateDesc(user)
-			.map(commitDate -> commitDate.getCommitDate().toLocalDate())
-			.orElse(null);
-
-		if (recentCommitDay == null) {
-			user.updateLastCommitUpdateTime(null);
-			return 0;
-		}
+		LocalDate recentCommitDay = hasTodayCommit ? today : yesterday;
 
 		int currentConsecutiveDays = user.getConsecutiveCommitDays();
 		LocalDate lastCommitDateAppliedDate = user.getLastCommitDateAppliedDate();
 
 		if (lastCommitDateAppliedDate == null || currentConsecutiveDays == 0) {
 			int newConsecutiveDays = 0;
-
 			LocalDate checkDate = recentCommitDay;
 
-			while (true) {
-				boolean hasCommit = commitRepository.existsByUserAndCommitDate(user, checkDate.atStartOfDay());
-				if (!hasCommit) {
-					break;
-				}
-
+			while (commitDateSet.contains(checkDate)) {
 				newConsecutiveDays++;
 				checkDate = checkDate.minusDays(1);
 			}
@@ -114,7 +108,14 @@ public class ExpService {
 			return currentConsecutiveDays + 1;
 		}
 
-		return currentConsecutiveDays;
+		int newConsecutiveDays = 0;
+		LocalDate checkDate = recentCommitDay;
+		while (commitDateSet.contains(checkDate)) {
+			newConsecutiveDays++;
+			checkDate = checkDate.minusDays(1);
+		}
+		user.updateLastCommitDateAppliedDate(recentCommitDay);
+		return newConsecutiveDays;
 	}
 
 	private int calculateBaseExp(List<Commit> uncalculatedCommits) {
@@ -125,8 +126,9 @@ public class ExpService {
 		return commitCounts * POINT_PER_COMMIT;
 	}
 
-	private int calculateTodayBonusExp(User user, List<Commit> uncalculatedCommits) {
+	private int calculateTodayBonusExp(List<Commit> uncalculatedCommits, Set<LocalDate> commitDateSet) {
 		int totalBonus = 0;
+
 		for (Commit commit : uncalculatedCommits) {
 			if (commit.isBonusAwarded()) {
 				continue;
@@ -134,7 +136,7 @@ public class ExpService {
 
 			LocalDate commitDate = commit.getCommitDate().toLocalDate();
 
-			int currentConsecutiveDays = getConsecutiveDaysForDate(user, commitDate);
+			int currentConsecutiveDays = getConsecutiveDaysForDate(commitDate, commitDateSet);
 
 			int dailyBonus = DAILY_BONUS_EXP + (BONUS_EXP_INCREASE * (currentConsecutiveDays - 1));
 			totalBonus += dailyBonus;
@@ -145,11 +147,11 @@ public class ExpService {
 		return totalBonus;
 	}
 
-	private int getConsecutiveDaysForDate(User user, LocalDate targetDate) {
+	private int getConsecutiveDaysForDate(LocalDate targetDate, Set<LocalDate> commitDateSet) {
 		int consecutiveDays = 1;
 		LocalDate checkDate = targetDate.minusDays(1);
 
-		while (commitRepository.existsByUserAndCommitDate(user, checkDate.atStartOfDay())) {
+		while (commitDateSet.contains(checkDate)) {
 			consecutiveDays++;
 			checkDate = checkDate.minusDays(1);
 		}
@@ -159,19 +161,14 @@ public class ExpService {
 
 	private int todayCommitCount(User user) {
 		LocalDateTime today = LocalDate.now().atStartOfDay();
-
 		return commitRepository.findAllByUserAndCommitDate(user, today).stream()
 			.mapToInt(Commit::getCnt)
 			.sum();
 	}
 
-	private int totalCommitCount(User user) {
-		int currentTotalCommitCount = user.getTotalCommitCount();
-		int newCommitCount = commitRepository.findAllByUserAndCalculatedFalse(user).stream()
-			.mapToInt(Commit::uncalculatedDelta)
-			.sum();
-
-		return currentTotalCommitCount + newCommitCount;
+	private int totalCommitCount(User user, List<Commit> newCommits) {
+		int newCount = newCommits.stream().mapToInt(Commit::uncalculatedDelta).sum();
+		return user.getTotalCommitCount() + newCount;
 	}
 
 	private void markCalculated(List<Commit> uncalculatedCommits) {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -37,7 +37,6 @@ public class ExpService {
 	private static final int DAILY_BONUS_EXP = 100;
 	private static final int BONUS_EXP_INCREASE = 10;
 
-	@RedissonLock(key = "#user.githubId")
 	public void calculateExpAndTier(User user) {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime lastUpdate = user.getLastCommitUpdateTime();

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.leets.commitatobe.domain.auth.service.AuthQueryService;
@@ -38,11 +37,8 @@ public class ExpService {
 	private static final int DAILY_BONUS_EXP = 100;
 	private static final int BONUS_EXP_INCREASE = 10;
 
-	@RedissonLock(key = "#githubId")
-	public void calculateExpAndTier(String githubId) {
-		User user = userRepository.findByGithubId(githubId)
-			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + githubId));
-
+	@RedissonLock(key = "#user.githubId")
+	public void calculateExpAndTier(User user) {
 		LocalDateTime now = LocalDateTime.now();
 		LocalDateTime lastUpdate = user.getLastCommitUpdateTime();
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -20,7 +20,6 @@ import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.global.config.redis.annotation.RedissonLock;
 import com.leets.commitatobe.global.exception.ApiException;
-import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -34,79 +33,115 @@ public class ExpService {
 	private final TierRepository tierRepository;
 	private final AuthQueryService authQueryService;
 
+	private static final int POINT_PER_COMMIT = 10;
 	private static final int DAILY_BONUS_EXP = 100;
 	private static final int BONUS_EXP_INCREASE = 10;
 
 	@RedissonLock(key = "#githubId")
-	public void calculateAndSaveExp(String githubId) {
+	public void calculateExpAndTier(String githubId) {
 		User user = userRepository.findByGithubId(githubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + githubId));
-		List<Commit> commits = commitRepository.findAllByUserOrderByCommitDateAsc(user); //사용자의 모든 커밋을 날짜 오름차순으로 불러온다.
 
-		int consecutiveDays = user.getConsecutiveCommitDays(); //연속 커밋 일수
-		LocalDateTime lastCommitDate = null; //마지막 커밋 날짜
-		int totalExp = user.getExp(); //사용자의 현재 경험치
+		int updatedConsecutiveDays = updateConsecutiveDays(user);
 
-		for (Commit commit : commits) {//각 커밋을 반복해서 계산
-			if (commit.isCalculated()) {
-				continue; // 이미 계산된 커밋
-			}
+		List<Commit> uncalculatedCommits = commitRepository.findAllByUserAndCalculatedFalse(user);
+		int baseExp = calculateBaseExp(uncalculatedCommits);
+		int bonusExp = calculateTodayBonusExp(user, updatedConsecutiveDays);
+		int totalExp = user.getExp() + baseExp + bonusExp;
 
-			LocalDateTime commitDate = commit.getCommitDate();//커밋날짜를 가져와 시간 설정
+		int todayCommitCount = todayCommitCount(user);
+		int totalCommitCount = totalCommitCount(user);
 
-			consecutiveDays = updateConsecutiveDays(lastCommitDate, commitDate, consecutiveDays);
-
-			totalExp += commit.calculateExp(DAILY_BONUS_EXP, consecutiveDays, BONUS_EXP_INCREASE);//총 경험치 업데이트
-
-			commit.markAsCalculated();//커밋 계산 여부를 true로 해서 다음 게산에서 제외
-			lastCommitDate = commitDate;//마지막 커밋날짜를 현재 커밋날짜로 업데이트
-		}
-
-		LocalDateTime today = LocalDate.now().atStartOfDay(); // 오늘 자정
-		LocalDateTime midnight = today.minusHours(9); // UTC와 KST 시간 차이를 맞추기 위함
-		int todayCommitCount = commits.stream()
-			.filter(c -> !c.getCommitDate().isBefore(midnight))
-			.mapToInt(Commit::getCnt)
-			.sum();
-
-		int totalCommitCount = commits.stream()
-			.mapToInt(Commit::getCnt)
-			.sum();
-
-		if (lastCommitDate != null && lastCommitDate.isBefore(LocalDateTime.now().minusDays(1))) {
-			consecutiveDays = 0;//마지막 커밋날짜가 어제보다 이전이면 연속 커밋 일수 초기화
-		}
-
-		user.updateExp(totalExp);//사용자 경험치 업데이트
-		Tier tier = determineTier(user.getExp());//경험치에 따른 티어 결정
-		user.updateTier(tier);
-		user.updateConsecutiveCommitDays(consecutiveDays);
-		user.updateTotalCommitCount(totalCommitCount);
+		user.updateExp(totalExp);
+		user.updateTier(determineTier(totalExp));
+		user.updateConsecutiveCommitDays(updatedConsecutiveDays);
 		user.updateTodayCommitCount(todayCommitCount);
+		user.updateTotalCommitCount(totalCommitCount);
+		user.updateLastCommitUpdateTime(LocalDateTime.now());
 
-		commitRepository.saveAll(commits);//변경된 커밋 정보 데이터베이스에 저장
-		userRepository.save(user);//변경된 사용자 정보 데이터베이스에 저장
+		markCalculated(uncalculatedCommits);
+
+		userRepository.save(user);
 	}
 
-	private int updateConsecutiveDays(LocalDateTime lastCommitDate, LocalDateTime commitDate,
-		int currentConsecutiveDays) {
-		// 첫 커밋일 경우
-		if (lastCommitDate == null) {
+	private int updateConsecutiveDays(User user) {
+		LocalDateTime today = LocalDateTime.now().toLocalDate().atStartOfDay();
+		LocalDateTime yesterday = today.minusDays(1);
+
+		boolean hasTodayCommit = commitRepository.existsByUserAndCommitDate(user, today);
+		boolean hasYesterdayCommit = commitRepository.existsByUserAndCommitDate(user, yesterday);
+		if (!hasTodayCommit && !hasYesterdayCommit) {
+			return 0;
+		}
+
+		int currentConsecutiveDays = user.getConsecutiveCommitDays();
+
+		LocalDate lastCommitDay = commitRepository.findTopByUserAndCalculatedTrueOrderByCommitDateDesc(user)
+			.map(commitDate -> commitDate.getCommitDate().toLocalDate())
+			.orElse(null);
+
+		if (lastCommitDay == null) {
 			return 1;
 		}
-		LocalDate lastDate = lastCommitDate.toLocalDate();
-		LocalDate currentDate = commitDate.toLocalDate();
 
-		// 이전 커밋 날 + 하루 = 현재 커밋 날짜일 경우 연속 커밋 일수 + 1
-		if (currentDate.equals(lastDate.plusDays(1))) {
-			return currentConsecutiveDays + 1;
-		}
+		LocalDate recentCommitDay = commitRepository.findTopByUserOrderByCommitDateDesc(user)
+			.map(commitDate -> commitDate.getCommitDate().toLocalDate())
+			.orElse(null);
 
-		if (currentDate.equals(lastDate)) {
+		if (recentCommitDay != null && recentCommitDay.equals(lastCommitDay)) {
 			return currentConsecutiveDays;
 		}
 
+		if (recentCommitDay != null && recentCommitDay.equals(lastCommitDay.plusDays(1))) {
+			return currentConsecutiveDays + 1;
+		}
+
 		return 1;
+	}
+
+	private int calculateBaseExp(List<Commit> uncalculatedCommits) {
+		int commitCounts = uncalculatedCommits.stream()
+			.mapToInt(Commit::getCnt)
+			.sum();
+
+		return commitCounts * POINT_PER_COMMIT;
+	}
+
+	private int calculateTodayBonusExp(User user, int consecutiveDays) {
+		LocalDateTime today = LocalDate.now().atStartOfDay();
+
+		boolean alreadyGotBonusExpToday = commitRepository.existsByUserAndCommitDateAndCalculatedTrue(user, today);
+		if (alreadyGotBonusExpToday) {
+			return 0;
+		}
+
+		boolean hasNewCommitToday = commitRepository.existsByUserAndCommitDate(user, today);
+		if (!hasNewCommitToday) {
+			return 0;
+		}
+
+		return DAILY_BONUS_EXP + (BONUS_EXP_INCREASE * (consecutiveDays - 1));
+	}
+
+	private int todayCommitCount(User user) {
+		LocalDateTime today = LocalDate.now().atStartOfDay();
+
+		return commitRepository.findAllByUserAndCommitDate(user, today).stream()
+			.mapToInt(Commit::getCnt)
+			.sum();
+	}
+
+	private int totalCommitCount(User user) {
+		int currentTotalCommitCount = user.getTotalCommitCount();
+		int newCommitCount = commitRepository.findAllByUserAndCalculatedFalse(user).stream()
+			.mapToInt(Commit::getCnt)
+			.sum();
+
+		return currentTotalCommitCount + newCommitCount;
+	}
+
+	private void markCalculated(List<Commit> uncalculatedCommits) {
+		uncalculatedCommits.forEach(Commit::markAsCalculated);
 	}
 
 	private Tier determineTier(Integer exp) {
@@ -114,7 +149,7 @@ public class ExpService {
 			.stream()
 			.filter(tier -> tier.isValid(exp))
 			.max(Comparator.comparing(Tier::getRequiredExp))
-			.orElseThrow(() -> new ApiException(ErrorStatus._TIER_NOT_FOUND));
+			.orElseThrow(() -> new ApiException(_TIER_NOT_FOUND));
 	}
 
 	public ExpAndTierResponse updateExpAndTier(int exp) {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -44,9 +44,9 @@ public class ExpService {
 
 		int updatedConsecutiveDays = updateConsecutiveDays(user);
 
-		List<Commit> uncalculatedCommits = commitRepository.findAllByUserAndCalculatedFalse(user);
+		List<Commit> uncalculatedCommits = commitRepository.findAllByUserAndCalculatedFalseOrderByCommitDateAsc(user);
 		int baseExp = calculateBaseExp(uncalculatedCommits);
-		int bonusExp = calculateTodayBonusExp(user, updatedConsecutiveDays);
+		int bonusExp = calculateTodayBonusExp(user, uncalculatedCommits);
 		int totalExp = user.getExp() + baseExp + bonusExp;
 
 		int todayCommitCount = todayCommitCount(user);
@@ -71,56 +71,90 @@ public class ExpService {
 		boolean hasTodayCommit = commitRepository.existsByUserAndCommitDate(user, today);
 		boolean hasYesterdayCommit = commitRepository.existsByUserAndCommitDate(user, yesterday);
 		if (!hasTodayCommit && !hasYesterdayCommit) {
+			user.updateLastCommitDateAppliedDate(null);
 			return 0;
-		}
-
-		int currentConsecutiveDays = user.getConsecutiveCommitDays();
-
-		LocalDate lastCommitDay = commitRepository.findTopByUserAndCalculatedTrueOrderByCommitDateDesc(user)
-			.map(commitDate -> commitDate.getCommitDate().toLocalDate())
-			.orElse(null);
-
-		if (lastCommitDay == null) {
-			return 1;
 		}
 
 		LocalDate recentCommitDay = commitRepository.findTopByUserOrderByCommitDateDesc(user)
 			.map(commitDate -> commitDate.getCommitDate().toLocalDate())
 			.orElse(null);
 
-		if (recentCommitDay != null && recentCommitDay.equals(lastCommitDay)) {
+		if (recentCommitDay == null) {
+			user.updateLastCommitUpdateTime(null);
+			return 0;
+		}
+
+		int currentConsecutiveDays = user.getConsecutiveCommitDays();
+		LocalDate lastCommitDateAppliedDate = user.getLastCommitDateAppliedDate();
+
+		if (lastCommitDateAppliedDate == null || currentConsecutiveDays == 0) {
+			int newConsecutiveDays = 0;
+
+			LocalDate checkDate = recentCommitDay;
+
+			while (true) {
+				boolean hasCommit = commitRepository.existsByUserAndCommitDate(user, checkDate.atStartOfDay());
+				if (!hasCommit) {
+					break;
+				}
+
+				newConsecutiveDays++;
+				checkDate = checkDate.minusDays(1);
+			}
+			user.updateLastCommitDateAppliedDate(recentCommitDay);
+			return newConsecutiveDays;
+		}
+
+		if (recentCommitDay.isEqual(lastCommitDateAppliedDate)) {
 			return currentConsecutiveDays;
 		}
 
-		if (recentCommitDay != null && recentCommitDay.equals(lastCommitDay.plusDays(1))) {
+		if (recentCommitDay.isEqual(lastCommitDateAppliedDate.plusDays(1))) {
+			user.updateLastCommitDateAppliedDate(recentCommitDay);
 			return currentConsecutiveDays + 1;
 		}
 
-		return 1;
+		return currentConsecutiveDays;
 	}
 
 	private int calculateBaseExp(List<Commit> uncalculatedCommits) {
 		int commitCounts = uncalculatedCommits.stream()
-			.mapToInt(Commit::getCnt)
+			.mapToInt(Commit::uncalculatedDelta)
 			.sum();
 
 		return commitCounts * POINT_PER_COMMIT;
 	}
 
-	private int calculateTodayBonusExp(User user, int consecutiveDays) {
-		LocalDateTime today = LocalDate.now().atStartOfDay();
+	private int calculateTodayBonusExp(User user, List<Commit> uncalculatedCommits) {
+		int totalBonus = 0;
+		for (Commit commit : uncalculatedCommits) {
+			if (commit.isBonusAwarded()) {
+				continue;
+			}
 
-		boolean alreadyGotBonusExpToday = commitRepository.existsByUserAndCommitDateAndCalculatedTrue(user, today);
-		if (alreadyGotBonusExpToday) {
-			return 0;
+			LocalDate commitDate = commit.getCommitDate().toLocalDate();
+
+			int currentConsecutiveDays = getConsecutiveDaysForDate(user, commitDate);
+
+			int dailyBonus = DAILY_BONUS_EXP + (BONUS_EXP_INCREASE * (currentConsecutiveDays - 1));
+			totalBonus += dailyBonus;
+
+			commit.todayBonusAwarded();
 		}
 
-		boolean hasNewCommitToday = commitRepository.existsByUserAndCommitDate(user, today);
-		if (!hasNewCommitToday) {
-			return 0;
+		return totalBonus;
+	}
+
+	private int getConsecutiveDaysForDate(User user, LocalDate targetDate) {
+		int consecutiveDays = 1;
+		LocalDate checkDate = targetDate.minusDays(1);
+
+		while (commitRepository.existsByUserAndCommitDate(user, checkDate.atStartOfDay())) {
+			consecutiveDays++;
+			checkDate = checkDate.minusDays(1);
 		}
 
-		return DAILY_BONUS_EXP + (BONUS_EXP_INCREASE * (consecutiveDays - 1));
+		return consecutiveDays;
 	}
 
 	private int todayCommitCount(User user) {
@@ -134,7 +168,7 @@ public class ExpService {
 	private int totalCommitCount(User user) {
 		int currentTotalCommitCount = user.getTotalCommitCount();
 		int newCommitCount = commitRepository.findAllByUserAndCalculatedFalse(user).stream()
-			.mapToInt(Commit::getCnt)
+			.mapToInt(Commit::uncalculatedDelta)
 			.sum();
 
 		return currentTotalCommitCount + newCommitCount;

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/ExpService.java
@@ -6,8 +6,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -22,6 +20,7 @@ import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.global.config.redis.annotation.RedissonLock;
 import com.leets.commitatobe.global.exception.ApiException;
+import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -44,114 +43,147 @@ public class ExpService {
 		User user = userRepository.findByGithubId(githubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + githubId));
 
-		Set<LocalDate> commitDateSet = commitRepository.findAllCommitDatesByUser(user).stream()
-			.map(LocalDateTime::toLocalDate)
-			.collect(Collectors.toSet());
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime lastUpdate = user.getLastCommitUpdateTime();
 
-		int updatedConsecutiveDays = updateConsecutiveDays(user, commitDateSet);
+		LocalDateTime windowStart = now.minusMonths(2).withDayOfMonth(1).toLocalDate().atStartOfDay();
 
-		List<Commit> uncalculatedCommits = commitRepository.findAllByUserAndCalculatedFalseOrderByCommitDateAsc(user);
-		int baseExp = calculateBaseExp(uncalculatedCommits);
-		int bonusExp = calculateTodayBonusExp(uncalculatedCommits, commitDateSet);
-		int totalExp = user.getExp() + baseExp + bonusExp;
+		List<Commit> windowCommits = commitRepository.findAllByUserAndCommitDateAfter(user,
+			windowStart.minusSeconds(1));
 
-		int todayCommitCount = todayCommitCount(user);
-		int totalCommitCount = totalCommitCount(user, uncalculatedCommits);
+		int calculatedWindowExp = calculateExpForCommits(windowCommits, user);
+		int calculatedWindowCommitCount = windowCommits.stream().mapToInt(Commit::getCnt).sum();
 
-		user.updateExp(totalExp);
-		user.updateTier(determineTier(totalExp));
-		user.updateConsecutiveCommitDays(updatedConsecutiveDays);
+		LocalDateTime nextDeductibleStart = now.minusMonths(1).withDayOfMonth(1).toLocalDate().atStartOfDay();
+		List<Commit> nextDeductibleCommits = windowCommits.stream()
+			.filter(c -> !c.getCommitDate().isBefore(nextDeductibleStart))
+			.toList();
+
+		int newNextMonthDeductibleExp = calculateExpForCommits(nextDeductibleCommits, user);
+		int newNextMonthDeductibleCommitCount = nextDeductibleCommits.stream().mapToInt(Commit::getCnt).sum();
+
+		int totalExp = user.getExp();
+		int totalCommitCount = user.getTotalCommitCount();
+
+		boolean isMonthChanged = lastUpdate != null && !lastUpdate.getMonth().equals(now.getMonth());
+
+		if (lastUpdate == null) {
+			totalExp += calculatedWindowExp;
+			totalCommitCount += calculatedWindowCommitCount;
+		} else if (isMonthChanged) {
+			totalExp = totalExp - user.getLastTwoMonthExp() + calculatedWindowExp;
+			totalCommitCount = totalCommitCount - user.getLastTwoMonthCommitCount() + calculatedWindowCommitCount;
+		} else {
+			totalExp = totalExp - user.getCurrentUpdateExp() + calculatedWindowExp;
+			totalCommitCount = totalCommitCount - user.getCurrentUpdateCommitCount() + calculatedWindowCommitCount;
+		}
+
+		int currentConsecutiveDays = calculateCurrentConsecutiveDays(user);
+		user.updateConsecutiveCommitDays(currentConsecutiveDays);
+
+		int todayCommitCount = windowCommits.stream()
+			.filter(commit -> commit.getCommitDate().toLocalDate().equals(now.toLocalDate()))
+			.mapToInt(Commit::getCnt)
+			.findFirst()
+			.orElse(0);
+
 		user.updateTodayCommitCount(todayCommitCount);
-		user.updateTotalCommitCount(totalCommitCount);
-		user.updateLastCommitUpdateTime(LocalDateTime.now());
+		user.updateExp(Math.max(0, totalExp));
+		user.updateTotalCommitCount(Math.max(0, totalCommitCount));
+		user.updateTier(determineTier(totalExp));
 
-		markCalculated(uncalculatedCommits);
+		user.updateCalcStats(
+			calculatedWindowExp,
+			calculatedWindowCommitCount,
+			newNextMonthDeductibleExp,
+			newNextMonthDeductibleCommitCount
+		);
+		user.updateLastCommitUpdateTime(now);
 
 		userRepository.save(user);
 	}
 
-	private int updateConsecutiveDays(User user, Set<LocalDate> commitDateSet) {
-		LocalDate today = LocalDate.now();
-		LocalDate yesterday = today.minusDays(1);
-
-		boolean hasTodayCommit = commitDateSet.contains(today);
-		boolean hasYesterdayCommit = commitDateSet.contains(yesterday);
-
-		if (!hasTodayCommit && !hasYesterdayCommit) {
-			user.updateLastCommitDateAppliedDate(null);
+	private int calculateExpForCommits(List<Commit> commits, User user) {
+		if (commits.isEmpty())
 			return 0;
-		}
 
-		LocalDate recentCommitDay = hasTodayCommit ? today : yesterday;
+		int baseExp = commits.stream()
+			.mapToInt(Commit::getCnt)
+			.sum() * POINT_PER_COMMIT;
 
-		int currentConsecutiveDays = user.getConsecutiveCommitDays();
-		LocalDate lastCommitDateAppliedDate = user.getLastCommitDateAppliedDate();
+		int bonusExp = calculateWindowBonusExp(commits, user);
 
-		if (lastCommitDateAppliedDate == null || currentConsecutiveDays == 0) {
-			int newConsecutiveDays = 0;
-			LocalDate checkDate = recentCommitDay;
-
-			while (commitDateSet.contains(checkDate)) {
-				newConsecutiveDays++;
-				checkDate = checkDate.minusDays(1);
-			}
-			user.updateLastCommitDateAppliedDate(recentCommitDay);
-			return newConsecutiveDays;
-		}
-
-		if (recentCommitDay.isEqual(lastCommitDateAppliedDate)) {
-			return currentConsecutiveDays;
-		}
-
-		if (recentCommitDay.isEqual(lastCommitDateAppliedDate.plusDays(1))) {
-			user.updateLastCommitDateAppliedDate(recentCommitDay);
-			return currentConsecutiveDays + 1;
-		}
-
-		int newConsecutiveDays = 0;
-		LocalDate checkDate = recentCommitDay;
-		while (commitDateSet.contains(checkDate)) {
-			newConsecutiveDays++;
-			checkDate = checkDate.minusDays(1);
-		}
-		user.updateLastCommitDateAppliedDate(recentCommitDay);
-		return newConsecutiveDays;
+		return baseExp + bonusExp;
 	}
 
-	private int calculateBaseExp(List<Commit> uncalculatedCommits) {
-		int commitCounts = uncalculatedCommits.stream()
-			.mapToInt(Commit::uncalculatedDelta)
-			.sum();
+	private int calculateWindowBonusExp(List<Commit> commits, User user) {
+		List<LocalDate> sortedDates = commits.stream()
+			.map(c -> c.getCommitDate().toLocalDate())
+			.distinct()
+			.sorted()
+			.toList();
 
-		return commitCounts * POINT_PER_COMMIT;
-	}
-
-	private int calculateTodayBonusExp(List<Commit> uncalculatedCommits, Set<LocalDate> commitDateSet) {
 		int totalBonus = 0;
+		int currentConsecutiveDays = 0;
+		LocalDate lastDate = null;
 
-		for (Commit commit : uncalculatedCommits) {
-			if (commit.isBonusAwarded()) {
-				continue;
+		for (LocalDate date : sortedDates) {
+			if (lastDate == null) {
+				currentConsecutiveDays = getInitialConsecutiveDaysForWindow(date, user);
+			} else if (date.equals(lastDate.plusDays(1))) {
+				currentConsecutiveDays++;
+			} else {
+				currentConsecutiveDays = 1;
 			}
-
-			LocalDate commitDate = commit.getCommitDate().toLocalDate();
-
-			int currentConsecutiveDays = getConsecutiveDaysForDate(commitDate, commitDateSet);
 
 			int dailyBonus = DAILY_BONUS_EXP + (BONUS_EXP_INCREASE * (currentConsecutiveDays - 1));
 			totalBonus += dailyBonus;
 
-			commit.todayBonusAwarded();
+			lastDate = date;
 		}
 
 		return totalBonus;
 	}
 
-	private int getConsecutiveDaysForDate(LocalDate targetDate, Set<LocalDate> commitDateSet) {
-		int consecutiveDays = 1;
-		LocalDate checkDate = targetDate.minusDays(1);
+	//월 시작일이 연속 커밋이 진행중인지 아닌지 판단
+	private int getInitialConsecutiveDaysForWindow(LocalDate windowStartDate, User user) {
+		LocalDate yesterday = windowStartDate.minusDays(1);
 
-		while (commitDateSet.contains(checkDate)) {
+		if (!commitRepository.existsByUserAndCommitDate(user, yesterday.atStartOfDay())) {
+			return 1;
+		}
+
+		int consecutiveDays = 1;
+		LocalDate checkDate = yesterday.minusDays(1);
+
+		while (commitRepository.existsByUserAndCommitDate(user, checkDate.atStartOfDay())) {
+			consecutiveDays++;
+			checkDate = checkDate.minusDays(1);
+		}
+
+		return consecutiveDays + 1;
+	}
+
+	private int calculateCurrentConsecutiveDays(User user) {
+		LocalDate today = LocalDate.now();
+
+		if (commitRepository.existsByUserAndCommitDate(user, today.atStartOfDay())) {
+			return countConsecutiveDaysFrom(user, today);
+		}
+
+		LocalDate yesterday = today.minusDays(1);
+		if (commitRepository.existsByUserAndCommitDate(user, yesterday.atStartOfDay())) {
+			return countConsecutiveDaysFrom(user, yesterday);
+		}
+
+		return 0;
+	}
+
+	private int countConsecutiveDaysFrom(User user, LocalDate startDate) {
+		int consecutiveDays = 0;
+		LocalDate checkDate = startDate;
+
+		while (commitRepository.existsByUserAndCommitDate(user, checkDate.atStartOfDay())) {
 			consecutiveDays++;
 			checkDate = checkDate.minusDays(1);
 		}
@@ -159,28 +191,12 @@ public class ExpService {
 		return consecutiveDays;
 	}
 
-	private int todayCommitCount(User user) {
-		LocalDateTime today = LocalDate.now().atStartOfDay();
-		return commitRepository.findAllByUserAndCommitDate(user, today).stream()
-			.mapToInt(Commit::getCnt)
-			.sum();
-	}
-
-	private int totalCommitCount(User user, List<Commit> newCommits) {
-		int newCount = newCommits.stream().mapToInt(Commit::uncalculatedDelta).sum();
-		return user.getTotalCommitCount() + newCount;
-	}
-
-	private void markCalculated(List<Commit> uncalculatedCommits) {
-		uncalculatedCommits.forEach(Commit::markAsCalculated);
-	}
-
 	private Tier determineTier(Integer exp) {
 		return tierRepository.findAll()
 			.stream()
 			.filter(tier -> tier.isValid(exp))
 			.max(Comparator.comparing(Tier::getRequiredExp))
-			.orElseThrow(() -> new ApiException(_TIER_NOT_FOUND));
+			.orElseThrow(() -> new ApiException(ErrorStatus._TIER_NOT_FOUND));
 	}
 
 	public ExpAndTierResponse updateExpAndTier(int exp) {

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -43,28 +44,30 @@ public class FetchCommits {
 		}
 
 		try {
-			gitHubService.updateToken(userQueryService.getUserGitHubAccessToken(gitHubId));
+			String accessToken = userQueryService.getUserGitHubAccessToken(gitHubId);
 
-			List<String> repos = gitHubService.fetchRepos(gitHubId);
+			List<String> repos = gitHubService.fetchRepos(accessToken, gitHubId);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
 			LocalDateTime finalDateTime = dateTime.minusHours(9); //UTC와 KST 시간 차이를 맞추기 위함.
 
+			Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
+
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
-					gitHubService.countCommits(fullName, gitHubId, finalDateTime);
+					gitHubService.countCommits(accessToken, fullName, gitHubId, finalDateTime, commitsByDate);
 				}, executor);
 				futures.add(voidCompletableFuture);
 			}
 
 			CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
 			allFutures.join();
-
 			executor.shutdown();
 
 			user.updateLastCommitUpdateTime(LocalDateTime.now());
+			userRepository.save(user);
 
-			saveCommits(user);
+			saveCommits(user, commitsByDate);
 
 			expService.calculateAndSaveExp(gitHubId);//커밋 가져온 후 경험치 계산 및 저장
 
@@ -75,9 +78,9 @@ public class FetchCommits {
 		return CommitResponse.of(true, user);
 	}
 
-	private void saveCommits(User user) {
+	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate) {
 		// 날짜별 커밋 수 DB에 저장
-		for (Map.Entry<LocalDateTime, Integer> entry : gitHubService.getCommitsByDate().entrySet()) {
+		for (Map.Entry<LocalDateTime, Integer> entry : commitsByDate.entrySet()) {
 			Commit commit = commitRepository.findByCommitDateAndUser(entry.getKey(), user)
 				.orElse(Commit.create(entry.getKey(), 0, user));
 			commit.updateCnt(entry.getValue() + commit.getCnt());

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -56,9 +56,8 @@ public class FetchCommits {
 			Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 
 			for (String fullName : repos) {
-				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
-					gitHubService.countCommits(accessToken, fullName, gitHubId, since, commitsByDate);
-				}, executor);
+				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() ->
+					gitHubService.countCommits(accessToken, fullName, gitHubId, since, commitsByDate), executor);
 				futures.add(voidCompletableFuture);
 			}
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -61,10 +61,13 @@ public class FetchCommits {
 
 			commitUpdateService.updateAndCalculate(user.getId(), commitsByDate);
 
+			User updatedUser = userRepository.findByGithubId(gitHubId)
+				.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));
+
+			return CommitResponse.of(true, updatedUser);
+
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
-
-		return CommitResponse.of(true, user);
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -19,6 +19,7 @@ import com.leets.commitatobe.domain.commit.repository.CommitRepository;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
+import com.leets.commitatobe.global.executor.LogExecutionTime;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,6 +33,7 @@ public class FetchCommits {
 	private final CommitUpdateService commitUpdateService;
 	private final UserQueryService userQueryService;
 
+	@LogExecutionTime
 	public CommitResponse execute() {
 		String gitHubId = authQueryService.getGitHubId();
 		User user = userRepository.findByGithubId(gitHubId)

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -59,7 +59,7 @@ public class FetchCommits {
 			allFutures.join();
 			executor.shutdown();
 
-			commitUpdateService.updateAndCalculate(user.getId(), commitsByDate);
+			commitUpdateService.updateAndCalculate(user, commitsByDate);
 
 			User updatedUser = userRepository.findByGithubId(gitHubId)
 				.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -29,7 +29,7 @@ public class FetchCommits {
 	private final UserRepository userRepository;
 	private final GitHubService gitHubService; // GitHub API 통신
 	private final AuthQueryService authQueryService;
-	private final ExpService expService;
+	private final CommitUpdateService commitUpdateService;
 	private final UserQueryService userQueryService;
 
 	public CommitResponse execute() {
@@ -49,7 +49,7 @@ public class FetchCommits {
 		try {
 			String accessToken = userQueryService.getUserGitHubAccessToken(gitHubId);
 
-			List<String> repos = gitHubService.fetchRepos(accessToken, gitHubId);
+			List<String> repos = gitHubService.fetchRepos(accessToken);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
 
@@ -65,24 +65,12 @@ public class FetchCommits {
 			allFutures.join();
 			executor.shutdown();
 
-			saveCommits(user, commitsByDate);
-
-			expService.calculateExpAndTier(gitHubId);
+			commitUpdateService.updateAndCalculate(user.getId(), commitsByDate);
 
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 
 		return CommitResponse.of(true, user);
-	}
-
-	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate) {
-		for (Map.Entry<LocalDateTime, Integer> entry : commitsByDate.entrySet()) {
-			LocalDateTime day = entry.getKey().toLocalDate().atStartOfDay();
-			int commitCounts = entry.getValue();
-
-			Commit commit = Commit.create(day, commitCounts, user);
-			commitRepository.save(commit);
-		}
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -1,5 +1,6 @@
 package com.leets.commitatobe.domain.commit.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +14,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import com.leets.commitatobe.domain.auth.service.AuthQueryService;
-import com.leets.commitatobe.domain.commit.domain.Commit;
 import com.leets.commitatobe.domain.commit.dto.response.CommitResponse;
 import com.leets.commitatobe.domain.commit.repository.CommitRepository;
 import com.leets.commitatobe.domain.user.domain.User;
@@ -39,28 +39,20 @@ public class FetchCommits {
 		User user = userRepository.findByGithubId(gitHubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));
 
-		LocalDateTime calculatedCursor = commitRepository.findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(user)
-			.map(Commit::getUpdatedAt)
-			.orElseGet(() -> user.getCreatedAt().toLocalDate().atStartOfDay());
-		LocalDateTime lastCommitUpdateTime = user.getLastCommitUpdateTime();
-
-		LocalDateTime since = (lastCommitUpdateTime == null)
-			? calculatedCursor :
-			(lastCommitUpdateTime.isAfter(calculatedCursor) ? lastCommitUpdateTime : calculatedCursor);
+		LocalDateTime since = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
 
 		try {
 			String accessToken = userQueryService.getUserGitHubAccessToken(gitHubId);
-
 			List<String> repos = gitHubService.fetchRepos(accessToken);
+
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
-
 			Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 
 			for (String fullName : repos) {
-				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() ->
+				CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
 					gitHubService.countCommits(accessToken, fullName, gitHubId, since, commitsByDate), executor);
-				futures.add(voidCompletableFuture);
+				futures.add(future);
 			}
 
 			CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -37,11 +37,14 @@ public class FetchCommits {
 		User user = userRepository.findByGithubId(gitHubId)
 			.orElseThrow(() -> new UsernameNotFoundException("해당하는 깃허브 닉네임과 일치하는 유저를 찾을 수 없음: " + gitHubId));
 
-		LocalDateTime dateTime = user.getLastCommitUpdateTime();
+		LocalDateTime calculatedCursor = commitRepository.findTopByUserAndCalculatedIsTrueOrderByUpdatedAtDesc(user)
+			.map(Commit::getUpdatedAt)
+			.orElseGet(() -> user.getCreatedAt().toLocalDate().atStartOfDay());
+		LocalDateTime lastCommitUpdateTime = user.getLastCommitUpdateTime();
 
-		if (dateTime == null) {
-			dateTime = user.getCreatedAt().toLocalDate().atStartOfDay();
-		}
+		LocalDateTime since = (lastCommitUpdateTime == null)
+			? calculatedCursor :
+			(lastCommitUpdateTime.isAfter(calculatedCursor) ? lastCommitUpdateTime : calculatedCursor);
 
 		try {
 			String accessToken = userQueryService.getUserGitHubAccessToken(gitHubId);
@@ -49,13 +52,12 @@ public class FetchCommits {
 			List<String> repos = gitHubService.fetchRepos(accessToken, gitHubId);
 			ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 			List<CompletableFuture<Void>> futures = new ArrayList<>();
-			LocalDateTime finalDateTime = dateTime.minusHours(9); //UTC와 KST 시간 차이를 맞추기 위함.
 
 			Map<LocalDateTime, Integer> commitsByDate = new ConcurrentHashMap<>();
 
 			for (String fullName : repos) {
 				CompletableFuture<Void> voidCompletableFuture = CompletableFuture.runAsync(() -> {
-					gitHubService.countCommits(accessToken, fullName, gitHubId, finalDateTime, commitsByDate);
+					gitHubService.countCommits(accessToken, fullName, gitHubId, since, commitsByDate);
 				}, executor);
 				futures.add(voidCompletableFuture);
 			}
@@ -79,11 +81,11 @@ public class FetchCommits {
 	}
 
 	private void saveCommits(User user, Map<LocalDateTime, Integer> commitsByDate) {
-		// 날짜별 커밋 수 DB에 저장
 		for (Map.Entry<LocalDateTime, Integer> entry : commitsByDate.entrySet()) {
-			Commit commit = commitRepository.findByCommitDateAndUser(entry.getKey(), user)
-				.orElse(Commit.create(entry.getKey(), 0, user));
-			commit.updateCnt(entry.getValue() + commit.getCnt());
+			LocalDateTime day = entry.getKey().toLocalDate().atStartOfDay();
+			int commitCounts = entry.getValue();
+
+			Commit commit = Commit.create(day, commitCounts, user);
 			commitRepository.save(commit);
 		}
 	}

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -19,7 +19,6 @@ import com.leets.commitatobe.domain.commit.repository.CommitRepository;
 import com.leets.commitatobe.domain.user.domain.User;
 import com.leets.commitatobe.domain.user.repository.UserRepository;
 import com.leets.commitatobe.domain.user.service.UserQueryService;
-import com.leets.commitatobe.global.executor.LogExecutionTime;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,7 +32,6 @@ public class FetchCommits {
 	private final CommitUpdateService commitUpdateService;
 	private final UserQueryService userQueryService;
 
-	@LogExecutionTime
 	public CommitResponse execute() {
 		String gitHubId = authQueryService.getGitHubId();
 		User user = userRepository.findByGithubId(gitHubId)

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/FetchCommits.java
@@ -66,12 +66,9 @@ public class FetchCommits {
 			allFutures.join();
 			executor.shutdown();
 
-			user.updateLastCommitUpdateTime(LocalDateTime.now());
-			userRepository.save(user);
-
 			saveCommits(user, commitsByDate);
 
-			expService.calculateAndSaveExp(gitHubId);//커밋 가져온 후 경험치 계산 및 저장
+			expService.calculateExpAndTier(gitHubId);
 
 		} catch (Exception e) {
 			throw new RuntimeException(e);

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 
 import org.springframework.http.HttpHeaders;
@@ -83,9 +82,7 @@ public class GitHubService {
 			}
 		});
 
-		return new ForkJoinPool(Runtime.getRuntime().availableProcessors()).submit(() ->
-			repoFullNames.parallelStream().toList()
-		).join();
+		return new ArrayList<>(repoFullNames);
 	}
 
 	// commit을 일별로 정리 (페이지네이션 병렬 처리)

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -45,6 +45,7 @@ public class GitHubService {
 	// GitHub repository 이름 저장
 	public List<String> fetchRepos(String accessToken) {
 		Set<String> repoFullNames = new HashSet<>();
+		LocalDateTime twoMonthsAgo = LocalDate.now().minusMonths(2).withDayOfMonth(1).atStartOfDay();
 
 		JsonArray repos = getConnection("/user/repos?type=all&sort=pushed&per_page=100", accessToken);
 		if (repos == null) {
@@ -52,8 +53,28 @@ public class GitHubService {
 		}
 
 		repos.forEach(repo -> {
-			String fullName = repo.getAsJsonObject().get("full_name").getAsString();
-			repoFullNames.add(fullName);
+			JsonObject repoObject = repo.getAsJsonObject();
+			String fullName = repoObject.get("full_name").getAsString();
+
+			// pushed_at 필드로 최근 활동 확인
+			if (repoObject.has("pushed_at") && !repoObject.get("pushed_at").isJsonNull()) {
+				String pushedAtStr = repoObject.get("pushed_at").getAsString();
+				try {
+					Instant pushedAt = Instant.parse(pushedAtStr);
+					LocalDateTime pushedDate = LocalDateTime.ofInstant(pushedAt, ZoneId.of("Asia/Seoul"));
+
+					// 최근 2개월 이내에 push가 있었던 레포지토리만 추가
+					if (pushedDate.isAfter(twoMonthsAgo)) {
+						repoFullNames.add(fullName);
+					}
+				} catch (Exception e) {
+					// 날짜 파싱 실패 시 안전하게 포함
+					repoFullNames.add(fullName);
+				}
+			} else {
+				// pushed_at 정보가 없으면 안전하게 포함
+				repoFullNames.add(fullName);
+			}
 		});
 
 		return new ForkJoinPool(Runtime.getRuntime().availableProcessors()).submit(() ->

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -6,16 +6,13 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -37,9 +34,6 @@ import reactor.core.publisher.Mono;
 @Getter
 public class GitHubService {
 	private final String GITHUB_API_URL = "https://api.github.com";
-	private String AUTH_TOKEN;
-	private final Map<LocalDateTime, Integer> commitsByDate = new HashMap<>();
-	private static final ThreadLocal<Boolean> REDIRECT_ON_401 = ThreadLocal.withInitial(() -> true);
 	private final WebClient webClient = WebClient.builder()
 		.baseUrl(GITHUB_API_URL)
 		.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -49,16 +43,11 @@ public class GitHubService {
 			.build())
 		.build();
 
-	@Value("${server-uri}")
-	private String SERVER_URI;
-
 	// GitHub repository 이름 저장
-	public List<String> fetchRepos(String gitHubUsername) {
-		commitsByDate.clear();
-
+	public List<String> fetchRepos(String accessToken, String gitHubUsername) {
 		Set<String> repoFullNames = new HashSet<>();
 
-		JsonArray repos = getConnection("/user/repos?type=all&sort=pushed&per_page=100");
+		JsonArray repos = getConnection("/user/repos?type=all&sort=pushed&per_page=100", accessToken);
 		if (repos == null) {
 			return new ArrayList<>();
 		}
@@ -70,18 +59,73 @@ public class GitHubService {
 
 		return new ForkJoinPool(Runtime.getRuntime().availableProcessors()).submit(() ->
 			repoFullNames.parallelStream()
-				.filter(fullName -> isContributor(fullName, gitHubUsername))
+				.filter(fullName -> isContributor(accessToken, fullName, gitHubUsername))
 				.toList()
 		).join();
 	}
 
+	// commit을 일별로 정리
+	public void countCommits(String accessToken, String fullName, String gitHubUsername, LocalDateTime date,
+		Map<LocalDateTime, Integer> commitsByDate) {
+		int page = 1;
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+		while (true) {
+			JsonArray commits;
+
+			try {
+				commits = getConnection(
+					"/repos/" + fullName + "/commits?page=" + page + "&per_page=100" + "&since=" + formatToISO8601(
+						date), accessToken);
+			} catch (Exception e) {
+				return;
+			}
+
+			if (commits == null || commits.isEmpty()) {
+				return;
+			}
+
+			for (int i = 0; i < commits.size(); i++) {
+				JsonObject commit = commits.get(i).getAsJsonObject();
+
+				if (!validateAuthor(commit, gitHubUsername)) {
+					continue;
+				}
+
+				String commitDateTime = getCommitDateTime(commit);
+				if (commitDateTime.length() < 10) {
+					continue;
+				}
+
+				LocalDateTime commitDate = LocalDate.parse(commitDateTime.substring(0, 10), formatter).atStartOfDay();
+				commitsByDate.merge(commitDate, 1, Integer::sum);
+			}
+
+			page++;
+		}
+	}
+
+	// http 연결
+	private JsonArray getConnection(String url, String accessToken) {
+		return webClient.get()
+			.uri(url)
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+			.retrieve()
+			.onStatus(s -> s.value() == 401,
+				r -> Mono.error(new ApiException(ErrorStatus._UNAUTHORIZED)))
+			.bodyToMono(String.class)
+			.map(res -> JsonParser.parseString(res).getAsJsonArray())
+			.block();
+	}
+
+
 	// 자신이 해당 repository의 기여자 인지 확인
-	private boolean isContributor(String fullName, String gitHubUsername) {
+	private boolean isContributor(String accessToken, String fullName, String gitHubUsername) {
 		if (fullName.contains(gitHubUsername)) {
 			return true;
 		}
 
-		JsonArray contributors = getConnection("/repos/" + fullName + "/contributors");
+		JsonArray contributors = getConnection("/repos/" + fullName + "/contributors", accessToken);
 
 		if (contributors == null) {
 			return false;
@@ -99,83 +143,6 @@ public class GitHubService {
 			}
 		}
 		return false;
-	}
-
-	// commit을 일별로 정리
-	public void countCommits(String fullName, String gitHubUsername, LocalDateTime date) {
-		int page = 1;
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-
-		while (true) {
-			JsonArray commits;
-
-			try {
-				commits = getConnection(
-					"/repos/" + fullName + "/commits?page=" + page + "&per_page=100" + "&since=" + formatToISO8601(
-						date));
-			} catch (Exception e) {
-				return;
-			}
-
-			if (commits == null || commits.isEmpty()) {
-				return;
-			}
-
-			for (int i = 0; i < commits.size(); i++) {
-				JsonObject commit = commits.get(i).getAsJsonObject();
-
-				// validateAuthor 메서드가 false, 즉 author가 null일 경우 스킵
-				if (!validateAuthor(commit, gitHubUsername)) {
-					continue;
-				}
-
-				String commitDateTime = getCommitDateTime(commit);
-				if (commitDateTime.length() < 10) {
-					continue;
-				}
-
-				int comparisonResult = commitDateTime.compareTo(formatToISO8601(date));
-				if (comparisonResult < 0) {
-					continue;
-				}
-
-				LocalDateTime commitDate = LocalDate.parse(commitDateTime.substring(0, 10), formatter).atStartOfDay();
-
-				synchronized (commitsByDate) {
-					commitsByDate.put(commitDate, commitsByDate.getOrDefault(commitDate, 0) + 1);
-				}
-			}
-
-			page++;
-		}
-	}
-
-	// http 연결
-	private JsonArray getConnection(String url) {
-		boolean redirect = REDIRECT_ON_401.get();
-
-		Mono<JsonArray> response = webClient.get()
-			.uri(url)
-			.header(HttpHeaders.AUTHORIZATION, "Bearer " + AUTH_TOKEN)
-			.retrieve()
-			.onStatus(status -> status == HttpStatus.UNAUTHORIZED, clientResponse ->
-				{
-					if (redirect) {
-						// AUTH_TOKEN이 유효하지 않으면 리다이렉트
-						return webClient.get()
-							.uri(SERVER_URI + "/login/github")
-							.retrieve()
-							.bodyToMono(Void.class)
-							.then(Mono.error(new ApiException(ErrorStatus._UNAUTHORIZED)));
-					} else {
-						return Mono.error(new ApiException(ErrorStatus._UNAUTHORIZED));
-					}
-				}
-			)
-			.bodyToMono(String.class)
-			.map(res -> JsonParser.parseString(res).getAsJsonArray());
-
-		return response.block();
 	}
 
 	private boolean validateAuthor(JsonObject commitJson, String gitHubUsername) {
@@ -207,32 +174,5 @@ public class GitHubService {
 	private String formatToISO8601(LocalDateTime dateTime) {
 		ZonedDateTime zonedDateTime = dateTime.atZone(ZoneOffset.UTC);
 		return DateTimeFormatter.ISO_INSTANT.format(zonedDateTime);
-	}
-
-	// GitHub Access Token 저장
-	public void updateToken(String accessToken) {
-		this.AUTH_TOKEN = accessToken;
-	}
-
-	public <T> T runWithoutRedirect(java.util.concurrent.Callable<T> work) {
-		boolean prev = REDIRECT_ON_401.get();
-		REDIRECT_ON_401.set(false);
-		try {
-			return work.call();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		} finally {
-			REDIRECT_ON_401.set(prev);
-		}
-	}
-
-	public void runWithoutRedirect(Runnable work) {
-		boolean prev = REDIRECT_ON_401.get();
-		REDIRECT_ON_401.set(false);
-		try {
-			work.run();
-		} finally {
-			REDIRECT_ON_401.set(prev);
-		}
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -10,7 +10,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.stream.IntStream;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -26,11 +30,13 @@ import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
 @Getter
+@Slf4j
 public class GitHubService {
 	private final String GITHUB_API_URL = "https://api.github.com";
 	private final WebClient webClient = WebClient.builder()
@@ -82,43 +88,119 @@ public class GitHubService {
 		).join();
 	}
 
-	// commit을 일별로 정리
+	// commit을 일별로 정리 (페이지네이션 병렬 처리)
 	public void countCommits(String accessToken, String fullName, String gitHubUsername, LocalDateTime date,
 		Map<LocalDateTime, Integer> commitsByDate) {
-		int page = 1;
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+		// 첫 페이지 조회로 커밋 존재 여부 확인
+		JsonArray firstPageCommits;
+		try {
+			firstPageCommits = fetchCommitPage(accessToken, fullName, gitHubUsername, date, 1);
+		} catch (Exception e) {
+			return;
+		}
+
+		if (firstPageCommits == null || firstPageCommits.isEmpty()) {
+			return;
+		}
+
+		// 첫 페이지 데이터 처리
+		processCommits(firstPageCommits, date, commitsByDate, formatter);
+
+		// 첫 페이지가 100개 미만이면 더 이상 페이지가 없음
+		if (firstPageCommits.size() < 100) {
+			return;
+		}
+
+		// 페이지 2부터 배치 단위로 병렬 조회
+		int currentBatch = 0;  // 0부터 시작으로 수정
+		int batchSize = 5; // 5페이지씩 병렬 조회
+		int totalPages = 1;
+
 		while (true) {
-			JsonArray commits;
+			int batchStart = currentBatch * batchSize + 2;  // +2로 수정 (페이지 1은 이미 처리)
+			int batchEnd = batchStart + batchSize - 1;
 
-			try {
-				commits = getConnection(
-					"/repos/" + fullName + "/commits?page=" + page + "&per_page=100" + "&since=" + formatToISO8601(
-						date) + "&author=" + gitHubUsername, accessToken);
-			} catch (Exception e) {
-				return;
-			}
+			// 배치 내의 모든 페이지를 병렬로 조회
+			List<CompletableFuture<JsonArray>> futures = IntStream.rangeClosed(batchStart, batchEnd)
+				.mapToObj(pageNum -> CompletableFuture.supplyAsync(() -> {
+					try {
+						return fetchCommitPage(accessToken, fullName, gitHubUsername, date, pageNum);
+					} catch (Exception e) {
+						return null;
+					}
+				}, pageExecutor))
+				.toList();
 
-			if (commits == null || commits.isEmpty()) {
-				return;
-			}
+			// 모든 페이지 조회 완료 대기
+			List<JsonArray> results = futures.stream()
+				.map(CompletableFuture::join)
+				.toList();
 
-			for (int i = 0; i < commits.size(); i++) {
-				JsonObject commit = commits.get(i).getAsJsonObject();
-
-				String commitDateTime = getCommitDateTime(commit);
-				if (commitDateTime.length() < 10) {
-					continue;
+			// 결과 처리 (순서대로 처리하며 조기 종료)
+			boolean hasMorePages = false;
+			for (JsonArray commits : results) {
+				if (commits == null || commits.isEmpty()) {
+					// 빈 페이지 발견 시 종료
+					break;
 				}
 
-				LocalDateTime commitDate = LocalDate.parse(commitDateTime.substring(0, 10), formatter).atStartOfDay();
-				if (commitDate.isBefore(date)) {
-					continue;
+				processCommits(commits, date, commitsByDate, formatter);
+				totalPages++;
+
+				if (commits.size() == 100) {
+					// 100개면 다음 페이지가 있을 가능성 있음
+					hasMorePages = true;
+				} else {
+					// 100개 미만이면 마지막 페이지이므로 종료
+					hasMorePages = false;
+					break;
 				}
-				commitsByDate.merge(commitDate, 1, Integer::sum);
 			}
 
-			page++;
+			// 더 이상 페이지가 없으면 종료
+			if (!hasMorePages) {
+				break;
+			}
+
+			currentBatch++;
+
+			// 안전장치: 최대 100페이지 (10,000개 커밋)까지만 조회
+			if (totalPages >= 100) {
+				log.warn("레포지토리 {}의 커밋이 100페이지(10,000개)를 초과하여 조회를 중단합니다.", fullName);
+				break;
+			}
+		}
+	}
+
+	// 페이지 병렬 조회용 ExecutorService (5개 스레드)
+	private final ExecutorService pageExecutor = Executors.newFixedThreadPool(5);
+
+	// 단일 페이지의 커밋 조회
+	private JsonArray fetchCommitPage(String accessToken, String fullName, String gitHubUsername,
+		LocalDateTime date, int page) {
+		return getConnection(
+			"/repos/" + fullName + "/commits?page=" + page + "&per_page=100&since=" + formatToISO8601(date)
+				+ "&author=" + gitHubUsername, accessToken);
+	}
+
+	// 커밋 데이터 처리
+	private void processCommits(JsonArray commits, LocalDateTime date, Map<LocalDateTime, Integer> commitsByDate,
+		DateTimeFormatter formatter) {
+		for (int i = 0; i < commits.size(); i++) {
+			JsonObject commit = commits.get(i).getAsJsonObject();
+
+			String commitDateTime = getCommitDateTime(commit);
+			if (commitDateTime.length() < 10) {
+				continue;
+			}
+
+			LocalDateTime commitDate = LocalDate.parse(commitDateTime.substring(0, 10), formatter).atStartOfDay();
+			if (commitDate.isBefore(date)) {
+				continue;
+			}
+			commitsByDate.merge(commitDate, 1, Integer::sum);
 		}
 	}
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -91,6 +91,9 @@ public class GitHubService {
 				}
 
 				LocalDateTime commitDate = LocalDate.parse(commitDateTime.substring(0, 10), formatter).atStartOfDay();
+				if (commitDate.isBefore(date)) {
+					continue;
+				}
 				commitsByDate.merge(commitDate, 1, Integer::sum);
 			}
 

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -19,7 +19,6 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.leets.commitatobe.global.exception.ApiException;
@@ -44,7 +43,7 @@ public class GitHubService {
 		.build();
 
 	// GitHub repository 이름 저장
-	public List<String> fetchRepos(String accessToken, String gitHubUsername) {
+	public List<String> fetchRepos(String accessToken) {
 		Set<String> repoFullNames = new HashSet<>();
 
 		JsonArray repos = getConnection("/user/repos?type=all&sort=pushed&per_page=100", accessToken);
@@ -58,9 +57,7 @@ public class GitHubService {
 		});
 
 		return new ForkJoinPool(Runtime.getRuntime().availableProcessors()).submit(() ->
-			repoFullNames.parallelStream()
-				.filter(fullName -> isContributor(accessToken, fullName, gitHubUsername))
-				.toList()
+			repoFullNames.parallelStream().toList()
 		).join();
 	}
 
@@ -76,7 +73,7 @@ public class GitHubService {
 			try {
 				commits = getConnection(
 					"/repos/" + fullName + "/commits?page=" + page + "&per_page=100" + "&since=" + formatToISO8601(
-						date), accessToken);
+						date) + "&author=" + gitHubUsername, accessToken);
 			} catch (Exception e) {
 				return;
 			}
@@ -87,10 +84,6 @@ public class GitHubService {
 
 			for (int i = 0; i < commits.size(); i++) {
 				JsonObject commit = commits.get(i).getAsJsonObject();
-
-				if (!validateAuthor(commit, gitHubUsername)) {
-					continue;
-				}
 
 				String commitDateTime = getCommitDateTime(commit);
 				if (commitDateTime.length() < 10) {
@@ -116,43 +109,6 @@ public class GitHubService {
 			.bodyToMono(String.class)
 			.map(res -> JsonParser.parseString(res).getAsJsonArray())
 			.block();
-	}
-
-	// 자신이 해당 repository의 기여자 인지 확인
-	private boolean isContributor(String accessToken, String fullName, String gitHubUsername) {
-		if (fullName.contains(gitHubUsername)) {
-			return true;
-		}
-
-		JsonArray contributors = getConnection("/repos/" + fullName + "/contributors", accessToken);
-
-		if (contributors == null) {
-			return false;
-		}
-
-		for (int i = 0; i < contributors.size(); i++) {
-			JsonObject contributor = contributors.get(i).getAsJsonObject();
-
-			if (contributor.has("login") && !contributor.get("login").isJsonNull()) {
-				String contributorLogin = contributor.get("login").getAsString();
-
-				if (contributorLogin.equals(gitHubUsername)) {
-					return true;
-				}
-			}
-		}
-		return false;
-	}
-
-	private boolean validateAuthor(JsonObject commitJson, String gitHubUsername) {
-		if (commitJson.has("author") && !commitJson.get("author").isJsonNull()) {
-			JsonElement topAuthor = commitJson.getAsJsonObject("author").get("login");
-			if (topAuthor != null && !topAuthor.isJsonNull()) {
-				return topAuthor.getAsString().equals(gitHubUsername);
-			}
-		}
-		// author가 null이면 해당 커밋을 스킵
-		return false;
 	}
 
 	// commit 시간 추출

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -30,6 +30,8 @@ import com.leets.commitatobe.global.response.code.status.ErrorStatus;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 @Service
@@ -94,7 +96,17 @@ public class GitHubService {
 		JsonArray firstPageCommits;
 		try {
 			firstPageCommits = fetchCommitPage(accessToken, fullName, gitHubUsername, date, 1);
+		} catch (ApiException e) {
+			log.warn("API 인증 오류로 커밋 조회 실패: {}", fullName);
+			return;
+		} catch (WebClientResponseException e) {
+			log.warn("HTTP 응답 오류로 커밋 조회 실패: {} - {} {}", e.getStatusCode(), fullName, e.getMessage());
+			return;
+		} catch (WebClientRequestException e) {
+			log.warn("네트워크 오류로 커밋 조회 실패: {} - {}", fullName, e.getMessage());
+			return;
 		} catch (Exception e) {
+			log.error("예상치 못한 예외로 커밋 조회 실패: {} - {}", fullName, e.getMessage(), e);
 			return;
 		}
 
@@ -124,7 +136,17 @@ public class GitHubService {
 				.mapToObj(pageNum -> CompletableFuture.supplyAsync(() -> {
 					try {
 						return fetchCommitPage(accessToken, fullName, gitHubUsername, date, pageNum);
+					} catch (ApiException e) {
+						log.warn("페이지 {} API 인증 오류: {}", pageNum, fullName);
+						return null;
+					} catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
+						log.warn("페이지 {} HTTP 응답 오류: {} - {}", pageNum, e.getStatusCode(), fullName);
+						return null;
+					} catch (org.springframework.web.reactive.function.client.WebClientRequestException e) {
+						log.warn("페이지 {} 네트워크 오류: {} - {}", pageNum, fullName, e.getMessage());
+						return null;
 					} catch (Exception e) {
+						log.error("페이지 {} 예상치 못한 예외: {} - {}", pageNum, fullName, e.getMessage(), e);
 						return null;
 					}
 				}, pageExecutor))

--- a/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
+++ b/src/main/java/com/leets/commitatobe/domain/commit/service/GitHubService.java
@@ -1,9 +1,9 @@
 package com.leets.commitatobe.domain.commit.service;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -118,7 +118,6 @@ public class GitHubService {
 			.block();
 	}
 
-
 	// 자신이 해당 repository의 기여자 인지 확인
 	private boolean isContributor(String accessToken, String fullName, String gitHubUsername) {
 		if (fullName.contains(gitHubUsername)) {
@@ -161,18 +160,17 @@ public class GitHubService {
 		String originCommitDateTime = commit.get("commit").getAsJsonObject() // UTC+0
 			.get("author").getAsJsonObject()
 			.get("date").getAsString();
+		Instant instant = Instant.parse(originCommitDateTime);
 
-		// 입력된 시간 문자열을 LocalDateTime으로 변환
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
-		LocalDateTime dateTime = LocalDateTime.parse(originCommitDateTime, formatter);
-
-		// 9시간 추가 -> UTC+9(한국 표준 시)
-		return dateTime.plusHours(9).format(formatter);
+		ZoneId kst = ZoneId.of("Asia/Seoul");
+		return instant.atZone(kst).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 	}
 
 	// GitHub API에서 제공하는 시간 표현법으로 변환
 	private String formatToISO8601(LocalDateTime dateTime) {
-		ZonedDateTime zonedDateTime = dateTime.atZone(ZoneOffset.UTC);
-		return DateTimeFormatter.ISO_INSTANT.format(zonedDateTime);
+		ZoneId kst = ZoneId.of("Asia/Seoul");
+		Instant instant = dateTime.atZone(kst).toInstant();
+
+		return DateTimeFormatter.ISO_INSTANT.format(instant);
 	}
 }

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.leets.commitatobe.domain.user.domain;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -66,6 +67,9 @@ public class User extends BaseTimeEntity {
 	private LocalDateTime lastCommitUpdateTime;
 
 	@Column
+	private LocalDate lastCommitDateAppliedDate;
+
+	@Column
 	private LocalDateTime lastLoginAt;
 
 	@Column
@@ -98,6 +102,10 @@ public class User extends BaseTimeEntity {
 
 	public void updateLastCommitUpdateTime(LocalDateTime lastCommitUpdateTime) {
 		this.lastCommitUpdateTime = lastCommitUpdateTime;
+	}
+
+	public void updateLastCommitDateAppliedDate(LocalDate lastCommitDateAppliedDate) {
+		this.lastCommitDateAppliedDate = lastCommitDateAppliedDate;
 	}
 
 	public void updateLastLoginAt(LocalDateTime loginAt) {

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -63,19 +63,19 @@ public class User extends BaseTimeEntity {
 	@JoinColumn(name = "tier_id")
 	private Tier tier;
 
-	@Column(name = "current-update-exp", nullable = false)
+	@Column(name = "current_update_exp", nullable = false)
 	@Builder.Default
 	private Integer currentUpdateExp = 0;
 
-	@Column(name = "current-update-commit-count", nullable = false)
+	@Column(name = "current_update_commit_count", nullable = false)
 	@Builder.Default
 	private Integer currentUpdateCommitCount = 0;
 
-	@Column(name = "last-two-month-exp", nullable = false)
+	@Column(name = "last_two_month_exp", nullable = false)
 	@Builder.Default
 	private Integer lastTwoMonthExp = 0;
 
-	@Column(name = "last-two-month-commit-count", nullable = false)
+	@Column(name = "last_two_month_commit_count", nullable = false)
 	@Builder.Default
 	private Integer lastTwoMonthCommitCount = 0;
 

--- a/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
+++ b/src/main/java/com/leets/commitatobe/domain/user/domain/User.java
@@ -63,11 +63,24 @@ public class User extends BaseTimeEntity {
 	@JoinColumn(name = "tier_id")
 	private Tier tier;
 
-	@Column
-	private LocalDateTime lastCommitUpdateTime;
+	@Column(name = "current-update-exp", nullable = false)
+	@Builder.Default
+	private Integer currentUpdateExp = 0;
+
+	@Column(name = "current-update-commit-count", nullable = false)
+	@Builder.Default
+	private Integer currentUpdateCommitCount = 0;
+
+	@Column(name = "last-two-month-exp", nullable = false)
+	@Builder.Default
+	private Integer lastTwoMonthExp = 0;
+
+	@Column(name = "last-two-month-commit-count", nullable = false)
+	@Builder.Default
+	private Integer lastTwoMonthCommitCount = 0;
 
 	@Column
-	private LocalDate lastCommitDateAppliedDate;
+	private LocalDateTime lastCommitUpdateTime;
 
 	@Column
 	private LocalDateTime lastLoginAt;
@@ -100,12 +113,16 @@ public class User extends BaseTimeEntity {
 		this.ranking = ranking;
 	}
 
-	public void updateLastCommitUpdateTime(LocalDateTime lastCommitUpdateTime) {
-		this.lastCommitUpdateTime = lastCommitUpdateTime;
+	public void updateCalcStats(int currentUpdateExp, int currentUpdateCommitCount,
+		int lastTwoMonthExp, int lastTwoMonthCommitCount) {
+		this.currentUpdateExp = currentUpdateExp;
+		this.currentUpdateCommitCount = currentUpdateCommitCount;
+		this.lastTwoMonthExp = lastTwoMonthExp;
+		this.lastTwoMonthCommitCount = lastTwoMonthCommitCount;
 	}
 
-	public void updateLastCommitDateAppliedDate(LocalDate lastCommitDateAppliedDate) {
-		this.lastCommitDateAppliedDate = lastCommitDateAppliedDate;
+	public void updateLastCommitUpdateTime(LocalDateTime lastCommitUpdateTime) {
+		this.lastCommitUpdateTime = lastCommitUpdateTime;
 	}
 
 	public void updateLastLoginAt(LocalDateTime loginAt) {
@@ -116,7 +133,7 @@ public class User extends BaseTimeEntity {
 		this.isHumanAccount = true;
 	}
 
-	public void reactivateAccount(){
+	public void reactivateAccount() {
 		this.isHumanAccount = false;
 	}
 }

--- a/src/main/java/com/leets/commitatobe/global/config/aop/AopForTransaction.java
+++ b/src/main/java/com/leets/commitatobe/global/config/aop/AopForTransaction.java
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AopForTransaction {
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional(propagation = Propagation.REQUIRED)
 	public Object proceed(final ProceedingJoinPoint joinPoint, String key) throws Throwable {
 		log.info("Lock 수행 : {}", key);
 		return joinPoint.proceed();

--- a/src/main/java/com/leets/commitatobe/global/config/aop/RedissonLockAop.java
+++ b/src/main/java/com/leets/commitatobe/global/config/aop/RedissonLockAop.java
@@ -8,6 +8,8 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import com.leets.commitatobe.global.config.parser.CustomSpringELParser;
@@ -18,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Aspect
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
 @Slf4j
 public class RedissonLockAop {

--- a/src/main/java/com/leets/commitatobe/global/executor/ExecutionTimeAspect.java
+++ b/src/main/java/com/leets/commitatobe/global/executor/ExecutionTimeAspect.java
@@ -1,0 +1,30 @@
+package com.leets.commitatobe.global.executor;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@Slf4j
+public class ExecutionTimeAspect {
+
+	@Around("@annotation(LogExecutionTime)")
+	public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+
+		Object proceed = joinPoint.proceed(); // 실제 메서드 실행
+
+		stopWatch.stop();
+		log.info("⏱️ [Performance] Method: {} | Execution Time: {} ms",
+			joinPoint.getSignature().toShortString(),
+			stopWatch.getTotalTimeMillis());
+
+		return proceed;
+	}
+}

--- a/src/main/java/com/leets/commitatobe/global/executor/ExecutionTimeAspect.java
+++ b/src/main/java/com/leets/commitatobe/global/executor/ExecutionTimeAspect.java
@@ -3,6 +3,7 @@ package com.leets.commitatobe.global.executor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Aspect
 @Component
+@Profile({"local"})
 @Slf4j
 public class ExecutionTimeAspect {
 

--- a/src/main/java/com/leets/commitatobe/global/executor/LogExecutionTime.java
+++ b/src/main/java/com/leets/commitatobe/global/executor/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package com.leets.commitatobe.global.executor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD) // 메서드에 붙이는 어노테이션
+@Retention(RetentionPolicy.RUNTIME) // 런타임까지 유지
+public @interface LogExecutionTime {
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -27,6 +27,10 @@ spring:
         format_sql: false
         use_sql_comments: false
         show_sql: false
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
     defer-datasource-initialization: true
     open-in-view: false
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,6 +26,10 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
     defer-datasource-initialization: true
     open-in-view: false
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -13,7 +13,7 @@ spring:
     name: commitato-BE
 
   datasource:
-    url: jdbc:mysql://localhost:3306/commitato
+    url: jdbc:mysql://localhost:3306/commitato?rewriteBatchedStatements=true
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -27,6 +27,10 @@ spring:
         format_sql: false
         use_sql_comments: false
         show_sql: false
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
     defer-datasource-initialization: true
     open-in-view: false
 

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -10,6 +10,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
     defer-datasource-initialization: true
 
   sql:


### PR DESCRIPTION
## ✅ PR 유형
깃허브 커밋 기록 및 경험치 계산 로직의 성능을 개선했습니다.

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

### 1. 경험치 계산 방식 변경
**기존의 문제점**: 사용자들의 경우 레포지토리를 private으로 설정하기도 하고, 다시 public으로 돌리는 경우도 많기 때문에 이전 기록된 커밋 기록에 대한 변경 자주 일어난다. 또한 특정 PR에 대한 머지가 오랜 시간이 지난 이후 merge가 이루어지는 경우도 많기에 이전 커밋 기록이 변경되는 경우 또한 상당히 많다. 따라서 이전 커밋 기록들도 관리를 해줘야하지만 이에 대한 처리가 이루어지지 않는다는 문제점이 존재.

**기존** : 사용자의 모든 과거 커밋을 DB에서 조회. for문을 돌며 처음부터 끝까지 연속 커밋일수와 보너스 경험치를 매번 다시 계산.

**수정** : 슬라이딩 윈도우 방식을 적용. 전체 기간이 아닌 횟수로 최근 3개월에 해당하는 데이터만 조회하도록 수정. 델타 업데이트 방식을 사용해 전체를 다시 계산하는 대신 기존 총점 - (지난달 변동분) + (이번달 변동분) 형태로 계산해 데이터 양이 많아지더라도 연산 속도가 일정하게 유지되도록 함.

### 2. Github API 통신 최적화
**-1. 조회 대상 레포지토리 필터링 강화**
**기존**: 모든 레포지토리를 가져온 뒤 isContributor 메서드로 해당 레포지토리 커밋이 기여자인지 여부를 판단.
**수정**: pushed_at 필드를 확인하여 최근 2개월 내 활동이 있는 레포지토리만 필터링. 또한 API 요청 시 &author = {githubId} 파라미터를 추가해 불필요한 검증 로직 제거

**-2. 커밋 조회 병렬 처리**
**기존**: while 루프 안에서 1페이지부터 순차적으로 호출: 앞 페이지 응답이 와야 다음 페이지를 요청.
**수정**: CompletableFuture와 ExecutorService를 사용해 5페이지씩(Batch) 병렬로 동시에 요청해 네트워크 대기 시간을 줄였음.

### 3. 스케줄러 및 구조 개선
**-1. 책임분리(단순하게 그렇다고 인지만 해주시면 됩니다.)**
기존 FetchCommits가 담당하는 비즈니스 로직을 CommitUpdateService로 이관하여 역할을 명확히 함.

**-2. 비동기 스케줄링**
**기존**: DailyCommitScheduler에서 유저를 순회하며 순차적으로 동기 처리. 한 유저의 처리가 늦어질 경우 전체 스케줄러가 지연.
**수정**: ExecutorService와 CompletableFuture를 사용해 여러 유저의 커밋 업데이트를 스케줄러 내에서 동시에 비동기로 처리.

## 결론
API 동작 시간이 기존 5890ms에서 3033ms로 약 **48.5%** 의 시간 단축을 이루어냄.
<img width="1546" height="32" alt="image" src="https://github.com/user-attachments/assets/c316a94d-9909-402b-8859-76294431fbec" />

---

## 🔗 관련 이슈
- close #112 

---

## 💡 추가 사항

